### PR TITLE
Replace dropped `package objects` with top-level definitions

### DIFF
--- a/core/src/main/scala/libretto/scaletto/impl/package.scala
+++ b/core/src/main/scala/libretto/scaletto/impl/package.scala
@@ -1,10 +1,8 @@
-package libretto.scaletto
+package libretto.scaletto.impl
 
-package object impl {
-  def bug[A](msg: String): A =
-    throw new AssertionError(
-      s"""$msg
-          |This is a bug, please report at https://github.com/TomasMikula/libretto/issues/new?labels=bug"""
-        .stripMargin
-    )
-}
+def bug[A](msg: String): A =
+  throw new AssertionError(
+    s"""$msg
+        |This is a bug, please report at https://github.com/TomasMikula/libretto/issues/new?labels=bug"""
+      .stripMargin
+  )

--- a/core/src/main/scala/libretto/util/atomic/package.scala
+++ b/core/src/main/scala/libretto/util/atomic/package.scala
@@ -1,54 +1,51 @@
-package libretto.util
+package libretto.util.atomic
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 
-package object atomic {
-
-  extension [A <: AnyRef](ref: AtomicReference[A]) {
-    def modifyOpaque[C](f: A => (A, C)): C = {
-      @tailrec def go(expected: A): C = {
-        val res: (A, C) = f(expected)
-        val changed: A = compareAndSetOpaque[A](ref, expected, res._1)
-        if (changed eq res._1)
-          res._2
-        else
-          go(changed)
-      }
-
-      go(ref.getOpaque())
+extension [A <: AnyRef](ref: AtomicReference[A]) {
+  def modifyOpaque[C](f: A => (A, C)): C = {
+    @tailrec def go(expected: A): C = {
+      val res: (A, C) = f(expected)
+      val changed: A = compareAndSetOpaque[A](ref, expected, res._1)
+      if (changed eq res._1)
+        res._2
+      else
+        go(changed)
     }
 
-    def modifyOpaqueWith[B, C](b: B, f: (A, B) => (A, C)): C = {
-      @tailrec def go(expected: A): C = {
-        val res: (A, C) = f(expected, b)
-        val changed: A = compareAndSetOpaque[A](ref, expected, res._1)
-        if (changed eq res._1) // success
-          res._2
-        else
-          go(changed)
-      }
-
-      go(ref.getOpaque())
-    }
+    go(ref.getOpaque())
   }
 
-  /** Returns the value of `ref` afterwards.
-    * If it is `next`, it means the operation was successful. Otherwise, the value has changed.
-    */
-  @tailrec private def compareAndSetOpaque[A <: AnyRef](
-    ref: AtomicReference[A],
-    expected: A,
-    next: A,
-  ): A = {
-    if (ref.weakCompareAndSetPlain(expected, next)) {
-      next // success
-    } else {
-      val current = ref.getOpaque()
-      if (current eq expected)
-        compareAndSetOpaque(ref, expected, next)
+  def modifyOpaqueWith[B, C](b: B, f: (A, B) => (A, C)): C = {
+    @tailrec def go(expected: A): C = {
+      val res: (A, C) = f(expected, b)
+      val changed: A = compareAndSetOpaque[A](ref, expected, res._1)
+      if (changed eq res._1) // success
+        res._2
       else
-        current
+        go(changed)
     }
+
+    go(ref.getOpaque())
+  }
+}
+
+/** Returns the value of `ref` afterwards.
+  * If it is `next`, it means the operation was successful. Otherwise, the value has changed.
+  */
+@tailrec private def compareAndSetOpaque[A <: AnyRef](
+  ref: AtomicReference[A],
+  expected: A,
+  next: A,
+): A = {
+  if (ref.weakCompareAndSetPlain(expected, next)) {
+    next // success
+  } else {
+    val current = ref.getOpaque()
+    if (current eq expected)
+      compareAndSetOpaque(ref, expected, next)
+    else
+      current
   }
 }

--- a/core/src/main/scala/libretto/util/package.scala
+++ b/core/src/main/scala/libretto/util/package.scala
@@ -1,5 +1,3 @@
-package libretto
+package libretto.util
 
-package object util {
-  type ∀[F[_]] = ForAll[F]
-}
+type ∀[F[_]] = ForAll[F]

--- a/examples/src/main/scala/libretto/examples/interactionNets/unaryArithmetic/package.scala
+++ b/examples/src/main/scala/libretto/examples/interactionNets/unaryArithmetic/package.scala
@@ -1,370 +1,368 @@
-package libretto.examples.interactionNets
+package libretto.examples.interactionNets.unaryArithmetic
 
 import libretto.scaletto.StarterKit._
 import libretto.scaletto.StarterKit.scalettoLib.given
 import libretto.lambda.util.SourcePos
 
-package object unaryArithmetic:
+opaque type Wire = Rec[WireF]
 
-  opaque type Wire = Rec[WireF]
+private type WireF[X] = Wire.ProperF[X] |+| Wire.AuxiliaryF[X]
 
-  private type WireF[X] = Wire.ProperF[X] |+| Wire.AuxiliaryF[X]
+object Wire {
+  private[unaryArithmetic] type ProperF[X] =
+    /* zero  */ One
+    /* succ  */ |+| X
+    /* plus  */ |+| (X |*| X)
+    /* times */ |+| (X |*| X)
+    /* dup   */ |+| (X |*| X)
+    /* erase */ |+| One
 
-  object Wire {
-    private[unaryArithmetic] type ProperF[X] =
-      /* zero  */ One
-      /* succ  */ |+| X
-      /* plus  */ |+| (X |*| X)
-      /* times */ |+| (X |*| X)
-      /* dup   */ |+| (X |*| X)
-      /* erase */ |+| One
+  opaque type Proper = ProperF[Wire]
 
-    opaque type Proper = ProperF[Wire]
+  object Proper {
+    def zero  : One             -⚬ Proper = injectL ∘ injectL ∘ injectL ∘ injectL ∘ injectL
+    def succ  : Wire            -⚬ Proper = injectL ∘ injectL ∘ injectL ∘ injectL ∘ injectR
+    def plus  : (Wire |*| Wire) -⚬ Proper = injectL ∘ injectL ∘ injectL ∘ injectR
+    def times : (Wire |*| Wire) -⚬ Proper = injectL ∘ injectL ∘ injectR
+    def dup   : (Wire |*| Wire) -⚬ Proper = injectL ∘ injectR
+    def eraser: One             -⚬ Proper = injectR
 
-    object Proper {
-      def zero  : One             -⚬ Proper = injectL ∘ injectL ∘ injectL ∘ injectL ∘ injectL
-      def succ  : Wire            -⚬ Proper = injectL ∘ injectL ∘ injectL ∘ injectL ∘ injectR
-      def plus  : (Wire |*| Wire) -⚬ Proper = injectL ∘ injectL ∘ injectL ∘ injectR
-      def times : (Wire |*| Wire) -⚬ Proper = injectL ∘ injectL ∘ injectR
-      def dup   : (Wire |*| Wire) -⚬ Proper = injectL ∘ injectR
-      def eraser: One             -⚬ Proper = injectR
-
-      def switchWith[A, R](
-        caseZero: A -⚬ R,
-        caseSucc: (A |*| Wire) -⚬ R,
-        casePlus: (A |*| (Wire |*| Wire)) -⚬ R,
-        caseTimes: (A |*| (Wire |*| Wire)) -⚬ R,
-        caseDup: (A |*| (Wire |*| Wire)) -⚬ R,
-        caseEraser: A -⚬ R,
-      ): (A |*| Proper) -⚬ R =
-        λ { case a |*| p =>
-          p switch {
-            case Right(?(eraser)) =>
-              caseEraser(a)
-            case Left(p) =>
-              p switch {
-                case Right(dup) =>
-                  caseDup(a |*| dup)
-                case Left(p) =>
-                  p switch {
-                    case Right(times) =>
-                      caseTimes(a |*| times)
-                    case Left(p) =>
-                      p switch {
-                        case Right(plus) =>
-                          casePlus(a |*| plus)
-                        case Left(p) =>
-                          p switch {
-                            case Right(succ) =>
-                              caseSucc(a |*| succ)
-                            case Left(?(zero)) =>
-                              caseZero(a)
-                          }
-                      }
-                  }
-              }
-          }
-        }
-
-      def switchWithR[B, T](
-        caseZero: B -⚬ T,
-        caseSucc: (Wire |*| B) -⚬ T,
-        casePlus: ((Wire |*| Wire) |*| B) -⚬ T,
-        caseTimes: ((Wire |*| Wire) |*| B) -⚬ T,
-        caseDup: ((Wire |*| Wire) |*| B) -⚬ T,
-        caseEraser: B -⚬ T,
-      ): (Proper |*| B) -⚬ T =
-        swap > switchWith(
-          caseZero,
-          swap > caseSucc,
-          swap > casePlus,
-          swap > caseTimes,
-          swap > caseDup,
-          caseEraser,
-        )
-
-      def switch[R](
-        caseZero: One -⚬ R,
-        caseSucc: Wire -⚬ R,
-        casePlus: (Wire |*| Wire) -⚬ R,
-        caseTimes: (Wire |*| Wire) -⚬ R,
-        caseDup: (Wire |*| Wire) -⚬ R,
-        caseEraser: One -⚬ R,
-      ): Proper -⚬ R =
-        introFst[Proper] > switchWith(
-          caseZero,
-          elimFst > caseSucc,
-          elimFst > casePlus,
-          elimFst > caseTimes,
-          elimFst > caseDup,
-          caseEraser,
-        )
-    }
-
-    private[unaryArithmetic] type AuxiliaryF[X] =
-      RedirectF[X] |+| OutletF[X]
-
-    private type RedirectF[X] = -[X]
-    private type OutletF[X] = -[ProperF[X] |+| LinkId]
-
-    opaque type LinkId = Val[AnyRef]
-
-    opaque type Auxiliary = AuxiliaryF[Wire]
-
-    opaque type Outlet = OutletF[Wire]
-
-    object Outlet {
-      def feedProper: (Proper |*| Outlet) -⚬ One =
-        λ { case p |*| out =>
-          injectL(p) supplyTo out
-        }
-
-      def feed: (Wire |*| Outlet) -⚬ One =
-        λ { case w |*| out =>
-          properOrLink(w) supplyTo out
-        }
-    }
-
-    object Auxiliary {
-      def redirect: -[Wire] -⚬ Auxiliary =
-        injectL
-
-      def outlet: -[Proper |+| LinkId] -⚬ Auxiliary =
-        injectR
-
-      def switch[R](w: $[Auxiliary])(f: LambdaContext ?=> Either[$[-[Wire]], $[Outlet]] => $[R])(using
-        pos: SourcePos,
-        ctx: LambdaContext,
-      ): $[R] =
-        $.switchEither(w, f)(pos)
-    }
-
-    def proper:       Proper -⚬ Wire = injectL > pack[WireF]
-    def auxiliary: Auxiliary -⚬ Wire = injectR > pack[WireF]
-
-    def newWire: One -⚬ (Wire |*| Wire) =
-      forevert[Wire] > fst(Auxiliary.redirect > auxiliary)
-
-    def switch[R](w: $[Wire])(f: LambdaContext ?=> Either[$[Proper], $[Auxiliary]] => $[R])(using
-      pos: SourcePos,
-      ctx: LambdaContext,
-    ): $[R] =
-      $.switchEither(w :>> unpack[WireF], f)(pos)
-
-    def read: Wire -⚬ Val[Result] = rec { read =>
-      λ { w =>
-        properOrLink(w) switch {
-          case Left(pw) =>
-            pw :>> Proper.switch(
-              caseZero = const(Result.Zero),
-              caseSucc = read > mapVal(Result.Succ(_)),
-              casePlus = par(read, read) > unliftPair > mapVal { case (b, out) => Result.Plus(b, out) },
-              caseTimes = par(read, read) > unliftPair > mapVal { case (b, out) => Result.Times(b, out) },
-              caseDup = par(read, read) > unliftPair > mapVal { case (x, y) => Result.Dup(x, y) },
-              caseEraser = const(Result.Eraser),
-            )
-          case Right(lnk) =>
-            lnk :>> mapVal(Result.Link(_))
-        }
-      }
-    }
-
-    private def properOrLink: Wire -⚬ (Proper |+| LinkId) =
-      λ { w =>
-        Wire.switch(w) {
+    def switchWith[A, R](
+      caseZero: A -⚬ R,
+      caseSucc: (A |*| Wire) -⚬ R,
+      casePlus: (A |*| (Wire |*| Wire)) -⚬ R,
+      caseTimes: (A |*| (Wire |*| Wire)) -⚬ R,
+      caseDup: (A |*| (Wire |*| Wire)) -⚬ R,
+      caseEraser: A -⚬ R,
+    ): (A |*| Proper) -⚬ R =
+      λ { case a |*| p =>
+        p switch {
+          case Right(?(eraser)) =>
+            caseEraser(a)
           case Left(p) =>
-            injectL(p)
-          case Right(aux) =>
-            Auxiliary.switch(aux) {
-              case Left(redir) =>
-                val (promised |*| res) = forevert[Proper |+| LinkId]($.one)
-                res alsoElim (
-                  auxiliary(Auxiliary.outlet(promised)) supplyTo redir
-                )
-              case Right(outlet) =>
-                val linkId = new AnyRef
-                constantVal(linkId) match {
-                  case +(lnk) =>
-                    injectR(lnk)
-                      .alsoElim(injectR(lnk) supplyTo outlet)
+            p switch {
+              case Right(dup) =>
+                caseDup(a |*| dup)
+              case Left(p) =>
+                p switch {
+                  case Right(times) =>
+                    caseTimes(a |*| times)
+                  case Left(p) =>
+                    p switch {
+                      case Right(plus) =>
+                        casePlus(a |*| plus)
+                      case Left(p) =>
+                        p switch {
+                          case Right(succ) =>
+                            caseSucc(a |*| succ)
+                          case Left(?(zero)) =>
+                            caseZero(a)
+                        }
+                    }
                 }
             }
         }
       }
+
+    def switchWithR[B, T](
+      caseZero: B -⚬ T,
+      caseSucc: (Wire |*| B) -⚬ T,
+      casePlus: ((Wire |*| Wire) |*| B) -⚬ T,
+      caseTimes: ((Wire |*| Wire) |*| B) -⚬ T,
+      caseDup: ((Wire |*| Wire) |*| B) -⚬ T,
+      caseEraser: B -⚬ T,
+    ): (Proper |*| B) -⚬ T =
+      swap > switchWith(
+        caseZero,
+        swap > caseSucc,
+        swap > casePlus,
+        swap > caseTimes,
+        swap > caseDup,
+        caseEraser,
+      )
+
+    def switch[R](
+      caseZero: One -⚬ R,
+      caseSucc: Wire -⚬ R,
+      casePlus: (Wire |*| Wire) -⚬ R,
+      caseTimes: (Wire |*| Wire) -⚬ R,
+      caseDup: (Wire |*| Wire) -⚬ R,
+      caseEraser: One -⚬ R,
+    ): Proper -⚬ R =
+      introFst[Proper] > switchWith(
+        caseZero,
+        elimFst > caseSucc,
+        elimFst > casePlus,
+        elimFst > caseTimes,
+        elimFst > caseDup,
+        caseEraser,
+      )
   }
 
-  import Wire.Outlet
+  private[unaryArithmetic] type AuxiliaryF[X] =
+    RedirectF[X] |+| OutletF[X]
 
-  enum Result {
-    case Zero
-    case Succ(n: Result)
-    case Plus(b: Result, out: Result)
-    case Times(b: Result, out: Result)
-    case Dup(b: Result, out: Result)
-    case Eraser
-    case Link(id: AnyRef)
+  private type RedirectF[X] = -[X]
+  private type OutletF[X] = -[ProperF[X] |+| LinkId]
+
+  opaque type LinkId = Val[AnyRef]
+
+  opaque type Auxiliary = AuxiliaryF[Wire]
+
+  opaque type Outlet = OutletF[Wire]
+
+  object Outlet {
+    def feedProper: (Proper |*| Outlet) -⚬ One =
+      λ { case p |*| out =>
+        injectL(p) supplyTo out
+      }
+
+    def feed: (Wire |*| Outlet) -⚬ One =
+      λ { case w |*| out =>
+        properOrLink(w) supplyTo out
+      }
   }
 
-  object Result {
-    def liftInt(n: Int): Result =
-      if (n > 0)
-        Succ(liftInt(n-1))
-      else
-        Zero
+  object Auxiliary {
+    def redirect: -[Wire] -⚬ Auxiliary =
+      injectL
+
+    def outlet: -[Proper |+| LinkId] -⚬ Auxiliary =
+      injectR
+
+    def switch[R](w: $[Auxiliary])(f: LambdaContext ?=> Either[$[-[Wire]], $[Outlet]] => $[R])(using
+      pos: SourcePos,
+      ctx: LambdaContext,
+    ): $[R] =
+      $.switchEither(w, f)(pos)
   }
 
-  def zero: One  -⚬ Wire = Wire.Proper.zero > Wire.proper
-  def succ: Wire -⚬ Wire = Wire.Proper.succ > Wire.proper
+  def proper:       Proper -⚬ Wire = injectL > pack[WireF]
+  def auxiliary: Auxiliary -⚬ Wire = injectR > pack[WireF]
 
-  def liftInt(n: Int): One -⚬ Wire =
-    if (n > 0)
-      liftInt(n-1) > succ
-    else
-      zero
+  def newWire: One -⚬ (Wire |*| Wire) =
+    forevert[Wire] > fst(Auxiliary.redirect > auxiliary)
 
-  /**
-    * `a + b = out`
-    *
-    * ```
-    *         _
-    *        | \
-    *    b --|  \
-    *        | + >-- a
-    *  out --|  /
-    *        |_/
-    *
-    * ```
-    */
-  def plus: (Wire |*| Wire) -⚬ Wire = Wire.Proper.plus > Wire.proper
+  def switch[R](w: $[Wire])(f: LambdaContext ?=> Either[$[Proper], $[Auxiliary]] => $[R])(using
+    pos: SourcePos,
+    ctx: LambdaContext,
+  ): $[R] =
+    $.switchEither(w :>> unpack[WireF], f)(pos)
 
-  def times: (Wire |*| Wire) -⚬ Wire = Wire.Proper.times > Wire.proper
-
-  def eraser: One -⚬ Wire = Wire.Proper.eraser > Wire.proper
-
-  def dup: (Wire |*| Wire) -⚬ Wire = Wire.Proper.dup > Wire.proper
-
-  def newWire: One -⚬ (Wire |*| Wire) = Wire.newWire
-
-  def readResult: Wire -⚬ Val[Result] = Wire.read
-
-  def connect: (Wire |*| Wire) -⚬ One = rec { self =>
-    λ { case (w1 |*| w2) =>
-      Wire.switch(w1) {
-        case Left(proper1) =>
-          Wire.switch(w2) {
-            case Left(proper2) => connectProper(self)(proper1 |*| proper2)
-            case Right(aux2) =>
-              Wire.Auxiliary.switch(aux2) {
-                case Left(redirect) => Wire.proper(proper1) supplyTo redirect
-                case Right(outlet)  => Outlet.feedProper(proper1 |*| outlet)
-              }
-          }
-        case Right(aux1) =>
-          Wire.Auxiliary.switch(aux1) {
-            case Left(redirect) => w2 supplyTo redirect
-            case Right(outlet)  => Outlet.feed(w2 |*| outlet)
-          }
+  def read: Wire -⚬ Val[Result] = rec { read =>
+    λ { w =>
+      properOrLink(w) switch {
+        case Left(pw) =>
+          pw :>> Proper.switch(
+            caseZero = const(Result.Zero),
+            caseSucc = read > mapVal(Result.Succ(_)),
+            casePlus = par(read, read) > unliftPair > mapVal { case (b, out) => Result.Plus(b, out) },
+            caseTimes = par(read, read) > unliftPair > mapVal { case (b, out) => Result.Times(b, out) },
+            caseDup = par(read, read) > unliftPair > mapVal { case (x, y) => Result.Dup(x, y) },
+            caseEraser = const(Result.Eraser),
+          )
+        case Right(lnk) =>
+          lnk :>> mapVal(Result.Link(_))
       }
     }
   }
 
-  /** Interaction rules for all 6x6 combinations. */
-  private def connectProper(
-    connect: (Wire |*| Wire) -⚬ One,
-  ): (Wire.Proper |*| Wire.Proper) -⚬ One = {
-    def duplicate: Wire -⚬ (Wire |*| Wire) =
-      λ { w =>
-        val a1 |*| a2 = constant(newWire)
-        val b1 |*| b2 = constant(newWire)
-        (a2 |*| b2) alsoElim connect(w |*| dup(a1 |*| b1))
+  private def properOrLink: Wire -⚬ (Proper |+| LinkId) =
+    λ { w =>
+      Wire.switch(w) {
+        case Left(p) =>
+          injectL(p)
+        case Right(aux) =>
+          Auxiliary.switch(aux) {
+            case Left(redir) =>
+              val (promised |*| res) = forevert[Proper |+| LinkId]($.one)
+              res alsoElim (
+                auxiliary(Auxiliary.outlet(promised)) supplyTo redir
+              )
+            case Right(outlet) =>
+              val linkId = new AnyRef
+              constantVal(linkId) match {
+                case +(lnk) =>
+                  injectR(lnk)
+                    .alsoElim(injectR(lnk) supplyTo outlet)
+              }
+          }
       }
+    }
+}
 
-    def plusSucc: ((Wire |*| Wire) |*| Wire) -⚬ One =
-      λ { case (b |*| out) |*| n =>
-        val o1 |*| o2 = constant(newWire)
-        val n1 = plus(b |*| o1)
-        connect(succ(o2) |*| out) alsoElim connect(n1 |*| n)
-      }
+import Wire.Outlet
 
-    def timesZero: (Wire |*| Wire) -⚬ One =
-      λ { case b |*| out => connect(constant(zero) |*| out) alsoElim erase(b) }
+enum Result {
+  case Zero
+  case Succ(n: Result)
+  case Plus(b: Result, out: Result)
+  case Times(b: Result, out: Result)
+  case Dup(b: Result, out: Result)
+  case Eraser
+  case Link(id: AnyRef)
+}
 
-    def timesSucc: ((Wire |*| Wire) |*| Wire) -⚬ One =
-      λ { case (b |*| out) |*| n =>
-        val b1 |*| b2 = duplicate(b)
-        val out0 = plus(b2 |*| out)
-        connect(times(b1 |*| out0) |*| n)
-      }
+object Result {
+  def liftInt(n: Int): Result =
+    if (n > 0)
+      Succ(liftInt(n-1))
+    else
+      Zero
+}
 
-    def dupZero: (Wire |*| Wire) -⚬ One =
-      λ { case w1 |*| w2 => connect(constant(zero) |*| w1) alsoElim connect(constant(zero) |*| w2) }
+def zero: One  -⚬ Wire = Wire.Proper.zero > Wire.proper
+def succ: Wire -⚬ Wire = Wire.Proper.succ > Wire.proper
 
-    def dupSucc: ((Wire |*| Wire) |*| Wire) -⚬ One =
-      λ { case (w1 |*| w2) |*| n =>
-        val n1 |*| n2 = duplicate(n)
-        connect(succ(n1) |*| w1) alsoElim connect(succ(n2) |*| w2)
-      }
+def liftInt(n: Int): One -⚬ Wire =
+  if (n > 0)
+    liftInt(n-1) > succ
+  else
+    zero
 
-    def erase: Wire -⚬ One =
-      λ { w => connect(w |*| constant(eraser)) }
+/**
+  * `a + b = out`
+  *
+  * ```
+  *         _
+  *        | \
+  *    b --|  \
+  *        | + >-- a
+  *  out --|  /
+  *        |_/
+  *
+  * ```
+  */
+def plus: (Wire |*| Wire) -⚬ Wire = Wire.Proper.plus > Wire.proper
 
-    Wire.Proper.switchWith(
-      caseZero =
-        Wire.Proper.switch(
-          caseZero = undefined("0", "0"),
-          caseSucc = undefined("0", "S"),
-          casePlus = connect,
-          caseTimes = timesZero,
-          caseDup = dupZero,
-          caseEraser = id[One],
-        ),
-      caseSucc =
-        Wire.Proper.switchWithR(
-          caseZero = undefined("S", "0"),
-          caseSucc = undefined("S", "S"),
-          casePlus = plusSucc,
-          caseTimes = timesSucc,
-          caseDup = dupSucc,
-          caseEraser = erase,
-        ),
-      casePlus =
-        Wire.Proper.switchWithR(
-          caseZero = connect,
-          caseSucc = swap > plusSucc,
-          casePlus = undefined("+", "+"),
-          caseTimes = undefined("+", "*"),
-          caseDup = undefined("+", "δ"),
-          caseEraser = parToOne(erase, erase),
-        ),
-      caseTimes =
-        Wire.Proper.switchWithR(
-          caseZero = swap > timesZero,
-          caseSucc = swap > timesSucc,
-          casePlus = undefined("*", "+"),
-          caseTimes = undefined("*", "*"),
-          caseDup = undefined("*", "δ"),
-          caseEraser = parToOne(erase, erase),
-        ),
-      caseDup =
-        Wire.Proper.switchWithR(
-          caseZero = dupZero,
-          caseSucc = swap > dupSucc,
-          casePlus = undefined("δ", "+"),
-          caseTimes = undefined("δ", "*"),
-          caseDup = λ { case (a1 |*| a2) |*| (b1 |*| b2) => connect(a1 |*| b1) alsoElim connect(a2 |*| b2) },
-          caseEraser = parToOne(erase, erase),
-        ),
-      caseEraser =
-        Wire.Proper.switch(
-          caseZero = id[One],
-          caseSucc = erase,
-          casePlus = parToOne(erase, erase),
-          caseTimes = parToOne(erase, erase),
-          caseDup = parToOne(erase, erase),
-          caseEraser = id[One],
-        ),
-    )
+def times: (Wire |*| Wire) -⚬ Wire = Wire.Proper.times > Wire.proper
+
+def eraser: One -⚬ Wire = Wire.Proper.eraser > Wire.proper
+
+def dup: (Wire |*| Wire) -⚬ Wire = Wire.Proper.dup > Wire.proper
+
+def newWire: One -⚬ (Wire |*| Wire) = Wire.newWire
+
+def readResult: Wire -⚬ Val[Result] = Wire.read
+
+def connect: (Wire |*| Wire) -⚬ One = rec { self =>
+  λ { case (w1 |*| w2) =>
+    Wire.switch(w1) {
+      case Left(proper1) =>
+        Wire.switch(w2) {
+          case Left(proper2) => connectProper(self)(proper1 |*| proper2)
+          case Right(aux2) =>
+            Wire.Auxiliary.switch(aux2) {
+              case Left(redirect) => Wire.proper(proper1) supplyTo redirect
+              case Right(outlet)  => Outlet.feedProper(proper1 |*| outlet)
+            }
+        }
+      case Right(aux1) =>
+        Wire.Auxiliary.switch(aux1) {
+          case Left(redirect) => w2 supplyTo redirect
+          case Right(outlet)  => Outlet.feed(w2 |*| outlet)
+        }
+    }
   }
+}
 
-  private def undefined[A, B](agent1: String, agent2: String): A -⚬ B =
-    crashNow(s"Undefined interaction between $agent1 and $agent2")
+/** Interaction rules for all 6x6 combinations. */
+private def connectProper(
+  connect: (Wire |*| Wire) -⚬ One,
+): (Wire.Proper |*| Wire.Proper) -⚬ One = {
+  def duplicate: Wire -⚬ (Wire |*| Wire) =
+    λ { w =>
+      val a1 |*| a2 = constant(newWire)
+      val b1 |*| b2 = constant(newWire)
+      (a2 |*| b2) alsoElim connect(w |*| dup(a1 |*| b1))
+    }
+
+  def plusSucc: ((Wire |*| Wire) |*| Wire) -⚬ One =
+    λ { case (b |*| out) |*| n =>
+      val o1 |*| o2 = constant(newWire)
+      val n1 = plus(b |*| o1)
+      connect(succ(o2) |*| out) alsoElim connect(n1 |*| n)
+    }
+
+  def timesZero: (Wire |*| Wire) -⚬ One =
+    λ { case b |*| out => connect(constant(zero) |*| out) alsoElim erase(b) }
+
+  def timesSucc: ((Wire |*| Wire) |*| Wire) -⚬ One =
+    λ { case (b |*| out) |*| n =>
+      val b1 |*| b2 = duplicate(b)
+      val out0 = plus(b2 |*| out)
+      connect(times(b1 |*| out0) |*| n)
+    }
+
+  def dupZero: (Wire |*| Wire) -⚬ One =
+    λ { case w1 |*| w2 => connect(constant(zero) |*| w1) alsoElim connect(constant(zero) |*| w2) }
+
+  def dupSucc: ((Wire |*| Wire) |*| Wire) -⚬ One =
+    λ { case (w1 |*| w2) |*| n =>
+      val n1 |*| n2 = duplicate(n)
+      connect(succ(n1) |*| w1) alsoElim connect(succ(n2) |*| w2)
+    }
+
+  def erase: Wire -⚬ One =
+    λ { w => connect(w |*| constant(eraser)) }
+
+  Wire.Proper.switchWith(
+    caseZero =
+      Wire.Proper.switch(
+        caseZero = undefined("0", "0"),
+        caseSucc = undefined("0", "S"),
+        casePlus = connect,
+        caseTimes = timesZero,
+        caseDup = dupZero,
+        caseEraser = id[One],
+      ),
+    caseSucc =
+      Wire.Proper.switchWithR(
+        caseZero = undefined("S", "0"),
+        caseSucc = undefined("S", "S"),
+        casePlus = plusSucc,
+        caseTimes = timesSucc,
+        caseDup = dupSucc,
+        caseEraser = erase,
+      ),
+    casePlus =
+      Wire.Proper.switchWithR(
+        caseZero = connect,
+        caseSucc = swap > plusSucc,
+        casePlus = undefined("+", "+"),
+        caseTimes = undefined("+", "*"),
+        caseDup = undefined("+", "δ"),
+        caseEraser = parToOne(erase, erase),
+      ),
+    caseTimes =
+      Wire.Proper.switchWithR(
+        caseZero = swap > timesZero,
+        caseSucc = swap > timesSucc,
+        casePlus = undefined("*", "+"),
+        caseTimes = undefined("*", "*"),
+        caseDup = undefined("*", "δ"),
+        caseEraser = parToOne(erase, erase),
+      ),
+    caseDup =
+      Wire.Proper.switchWithR(
+        caseZero = dupZero,
+        caseSucc = swap > dupSucc,
+        casePlus = undefined("δ", "+"),
+        caseTimes = undefined("δ", "*"),
+        caseDup = λ { case (a1 |*| a2) |*| (b1 |*| b2) => connect(a1 |*| b1) alsoElim connect(a2 |*| b2) },
+        caseEraser = parToOne(erase, erase),
+      ),
+    caseEraser =
+      Wire.Proper.switch(
+        caseZero = id[One],
+        caseSucc = erase,
+        casePlus = parToOne(erase, erase),
+        caseTimes = parToOne(erase, erase),
+        caseDup = parToOne(erase, erase),
+        caseEraser = id[One],
+      ),
+  )
+}
+
+private def undefined[A, B](agent1: String, agent2: String): A -⚬ B =
+  crashNow(s"Undefined interaction between $agent1 and $agent2")

--- a/examples/src/main/scala/libretto/examples/sunflowers/package.scala
+++ b/examples/src/main/scala/libretto/examples/sunflowers/package.scala
@@ -1,7 +1,5 @@
-package libretto.examples
+package libretto.examples.sunflowers
 
-package object sunflowers {
-  case class Sunflower()
-  case class SeedsPack()
-  case class OilBottle()
-}
+case class Sunflower()
+case class SeedsPack()
+case class OilBottle()

--- a/libretto-zio/src/main/scala/libretto/zio_interop/package.scala
+++ b/libretto-zio/src/main/scala/libretto/zio_interop/package.scala
@@ -1,20 +1,16 @@
-package libretto
+package libretto.zio_interop
 
 import libretto.stream.scaletto.DefaultStreams.ValSource
 import libretto.util.Async
 import zio.{UIO, ZIO}
 import zio.stream.UStream
 
-package object zio_interop {
+extension [A](stream: UStream[A]) {
+  def asSource: Ztuff[ValSource[A]] =
+    Ztuff.ZioUStream(stream)
+}
 
-  extension [A](stream: UStream[A]) {
-    def asSource: Ztuff[ValSource[A]] =
-      Ztuff.ZioUStream(stream)
-  }
-
-  extension [A](fa: Async[A]) {
-    def toZIO: UIO[A] =
-      ZIO.async(callback => fa.onComplete(a => callback(ZIO.succeed(a))))
-  }
-
+extension [A](fa: Async[A]) {
+  def toZIO: UIO[A] =
+    ZIO.async(callback => fa.onComplete(a => callback(ZIO.succeed(a))))
 }

--- a/mashup/src/main/scala/libretto/mashup/package.scala
+++ b/mashup/src/main/scala/libretto/mashup/package.scala
@@ -1,28 +1,26 @@
-package libretto
+package libretto.mashup
 
 import java.util.concurrent.ScheduledExecutorService
 import libretto.util.Async
 import zio.ZIO
 
-package object mashup {
-  val kit: MashupKit = MashupKitImpl
+val kit: MashupKit = MashupKitImpl
 
-  val dsl: kit.dsl.type = kit.dsl
+val dsl: kit.dsl.type = kit.dsl
 
-  type Runtime = MashupRuntime[dsl.type]
+type Runtime = MashupRuntime[dsl.type]
 
-  object Runtime {
-    def create(executor: ScheduledExecutorService): Runtime =
-      kit.createRuntime(executor)
-  }
+object Runtime {
+  def create(executor: ScheduledExecutorService): Runtime =
+    kit.createRuntime(executor)
+}
 
-  extension [A](a: Async[A]) {
-    def toZIO: ZIO[Any, Nothing, A] =
-      a match {
-        case Async.Now(a) =>
-          ZIO.succeed(a)
-        case Async.Later(register) =>
-          ZIO.async(callback => register(a => callback(ZIO.succeed(a))))
-      }
-  }
+extension [A](a: Async[A]) {
+  def toZIO: ZIO[Any, Nothing, A] =
+    a match {
+      case Async.Now(a) =>
+        ZIO.succeed(a)
+      case Async.Later(register) =>
+        ZIO.async(callback => register(a => callback(ZIO.succeed(a))))
+    }
 }

--- a/stream/src/main/scala/libretto/stream/package.scala
+++ b/stream/src/main/scala/libretto/stream/package.scala
@@ -1,11 +1,9 @@
-package libretto
+package libretto.stream
 
 import libretto.scaletto.StarterKit
 
-package object stream {
-  val DefaultStreams =
-    InvertStreams(
-      StarterKit.dsl,
-      StarterKit.coreLib,
-    )
-}
+val DefaultStreams =
+  InvertStreams(
+    StarterKit.dsl,
+    StarterKit.coreLib,
+  )

--- a/stream/src/main/scala/libretto/stream/scaletto/package.scala
+++ b/stream/src/main/scala/libretto/stream/scaletto/package.scala
@@ -1,13 +1,11 @@
-package libretto.stream
+package libretto.stream.scaletto
 
 import libretto.scaletto.StarterKit
 
-package object scaletto {
-  val DefaultStreams =
-    ScalettoStreams(
-      StarterKit.dsl,
-      StarterKit.coreLib,
-      StarterKit.scalettoLib,
-      libretto.stream.DefaultStreams,
-    )
-}
+val DefaultStreams =
+  ScalettoStreams(
+    StarterKit.dsl,
+    StarterKit.coreLib,
+    StarterKit.scalettoLib,
+    libretto.stream.DefaultStreams,
+  )

--- a/testing/src/main/scala/libretto/testing/scaletto/package.scala
+++ b/testing/src/main/scala/libretto/testing/scaletto/package.scala
@@ -1,7 +1,5 @@
-package libretto.testing
+package libretto.testing.scaletto
 
 import libretto.scaletto.StarterKit
 
-package object scaletto {
-  type StarterTestKit = ScalettoTestKit.Of[StarterKit.dsl.type]
-}
+type StarterTestKit = ScalettoTestKit.Of[StarterKit.dsl.type]


### PR DESCRIPTION
Please see: https://docs.scala-lang.org/scala3/reference/dropped-features/package-objects.html for motivation.

Drive-by commit while I'm reading code… :smile: