### PR TITLE
Future proofing: Rewrite implicit to Scala 3 replacements

### DIFF
--- a/core-tests/src/test/scala/libretto/BasicTests.scala
+++ b/core-tests/src/test/scala/libretto/BasicTests.scala
@@ -2,16 +2,16 @@ package libretto
 
 import java.util.concurrent.{Executors, ScheduledExecutorService}
 import java.util.concurrent.atomic.AtomicInteger
-import libretto.Functor._
+import libretto.Functor.*
 import libretto.lambda.util.SourcePos
-import libretto.lambda.util.Monad.syntax._
+import libretto.lambda.util.Monad.syntax.*
 import libretto.scaletto.ScalettoLib
 import libretto.testing.{TestCase, TestExecutor, TestKit}
 import libretto.testing.scaletto.{ScalettoTestExecutor, ScalettoTestKit}
 import libretto.testing.scalatest.ScalatestSuite
 import libretto.util.Async
 import scala.concurrent.{Await, Promise}
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class BasicTests extends ScalatestSuite[ScalettoTestKit] {
   private var scheduler: ScheduledExecutorService = _
@@ -38,13 +38,13 @@ class BasicTests extends ScalatestSuite[ScalettoTestKit] {
     )
 
   override def testCases(using kit: ScalettoTestKit): List[(String, TestCase[kit.type])] = {
-    import kit.{OutPort => _, _}
-    import dsl._
-    import dsl.$._
+    import kit.{OutPort => _, *}
+    import dsl.*
+    import dsl.$.*
     val coreLib = CoreLib(dsl)
     val scalettoLib = ScalettoLib(dsl: dsl.type, coreLib)
-    import coreLib.{_, given}
-    import scalettoLib.{_, given}
+    import coreLib.{*, given}
+    import scalettoLib.{*, given}
     import kit.bridge.Execution
 
     def raceKeepWinner[A](

--- a/core-tests/src/test/scala/libretto/BasicTests.scala
+++ b/core-tests/src/test/scala/libretto/BasicTests.scala
@@ -43,7 +43,7 @@ class BasicTests extends ScalatestSuite[ScalettoTestKit] {
     import dsl.$._
     val coreLib = CoreLib(dsl)
     val scalettoLib = ScalettoLib(dsl: dsl.type, coreLib)
-    import coreLib._
+    import coreLib.{_, given}
     import scalettoLib.{_, given}
     import kit.bridge.Execution
 

--- a/core-tests/src/test/scala/libretto/ClosureTests.scala
+++ b/core-tests/src/test/scala/libretto/ClosureTests.scala
@@ -1,6 +1,6 @@
 package libretto
 
-import libretto.lambda.util.Monad.syntax._
+import libretto.lambda.util.Monad.syntax.*
 import libretto.scaletto.ScalettoLib
 import libretto.testing.TestCase
 import libretto.testing.scaletto.ScalettoTestKit
@@ -8,15 +8,15 @@ import libretto.testing.scalatest.scaletto.ScalatestScalettoTestSuite
 
 class ClosureTests extends ScalatestScalettoTestSuite {
   override def testCases(using kit: ScalettoTestKit): List[(String, TestCase[kit.type])] = {
-    import kit.dsl._
-    import kit.dsl.$._
+    import kit.dsl.*
+    import kit.dsl.$.*
     import kit.{Outcome, expectVal}
     import kit.Outcome.expectNotThrows
 
     val coreLib = CoreLib(kit.dsl)
     val scalettoLib = ScalettoLib(kit.dsl, coreLib)
-    import coreLib._
-    import scalettoLib.{_, given}
+    import coreLib.*
+    import scalettoLib.{*, given}
 
     List(
       "simplest closure" ->

--- a/core-tests/src/test/scala/libretto/ClosureTests.scala
+++ b/core-tests/src/test/scala/libretto/ClosureTests.scala
@@ -16,7 +16,7 @@ class ClosureTests extends ScalatestScalettoTestSuite {
     val coreLib = CoreLib(kit.dsl)
     val scalettoLib = ScalettoLib(kit.dsl, coreLib)
     import coreLib._
-    import scalettoLib._
+    import scalettoLib.{_, given}
 
     List(
       "simplest closure" ->

--- a/core/src/main/scala/libretto/Bifunctor.scala
+++ b/core/src/main/scala/libretto/Bifunctor.scala
@@ -26,7 +26,7 @@ trait Bifunctor[->[_, _], F[_, _]] { self =>
         Bifunctor.this.lift[A, A, B1, B2](this.category.id[A], g)
     }
 
-  def inside[G[_]](implicit G: Functor[->, G]): Bifunctor[->, λ[(x, y) => G[F[x, y]]]] =
+  def inside[G[_]](using G: Functor[->, G]): Bifunctor[->, λ[(x, y) => G[F[x, y]]]] =
     new Bifunctor[->, λ[(x, y) => G[F[x, y]]]] {
       override val category =
         self.category

--- a/core/src/main/scala/libretto/Bridge.scala
+++ b/core/src/main/scala/libretto/Bridge.scala
@@ -15,7 +15,7 @@ trait CoreBridge {
 
 trait CoreExecution[DSL <: CoreDSL] {
   val dsl: DSL
-  import dsl._
+  import dsl.*
 
   type OutPort[A]
   val OutPort: OutPorts

--- a/core/src/main/scala/libretto/ClosedLib.scala
+++ b/core/src/main/scala/libretto/ClosedLib.scala
@@ -16,8 +16,8 @@ class ClosedLib[
   val dsl: DSL,
   val coreLib: CLib with CoreLib[dsl.type],
 ) { lib =>
-  import dsl._
-  import coreLib._
+  import dsl.*
+  import coreLib.*
 
   /** Function object (internal hom) is contravariant in the input type. */
   def input[C]: ContraFunctor[[x] =>> x =⚬ C] =

--- a/core/src/main/scala/libretto/ClosedLib.scala
+++ b/core/src/main/scala/libretto/ClosedLib.scala
@@ -43,15 +43,15 @@ class ClosedLib[
         out(f)
     }
 
-  implicit class ClosedLinearFunctionOps[A, B](self: A -⚬ B) {
-    def curry[A1, A2](implicit ev: A =:= (A1 |*| A2)): A1 -⚬ (A2 =⚬ B) =
-      dsl.curry(ev.substituteCo[λ[x => x -⚬ B]](self))
+  extension [A, B](f: A -⚬ B) {
+    def curry[A1, A2](using ev: A =:= (A1 |*| A2)): A1 -⚬ (A2 =⚬ B) =
+      dsl.curry(ev.substituteCo[λ[x => x -⚬ B]](f))
 
-    def uncurry[B1, B2](implicit ev: B =:= (B1 =⚬ B2)): (A |*| B1) -⚬ B2 =
-      dsl.uncurry(ev.substituteCo(self))
+    def uncurry[B1, B2](using ev: B =:= (B1 =⚬ B2)): (A |*| B1) -⚬ B2 =
+      dsl.uncurry(ev.substituteCo(f))
   }
 
-  implicit class FocusedOnFunctionCo[F[_], A, B](f: FocusedCo[F, A =⚬ B]) {
+  extension [F[_], A, B](f: FocusedCo[F, A =⚬ B]) {
     def input: FocusedContra[λ[x => F[x =⚬ B]], A] =
       f.zoomContra(lib.input[B])
 
@@ -59,7 +59,7 @@ class ClosedLib[
       f.zoomCo(lib.output[A])
   }
 
-  implicit class FocusedOnFunctionContra[F[_], A, B](f: FocusedContra[F, A =⚬ B]) {
+  extension [F[_], A, B](f: FocusedContra[F, A =⚬ B]) {
     def input: FocusedCo[λ[x => F[x =⚬ B]], A] =
       f.zoomContra(lib.input[B])
 
@@ -67,7 +67,7 @@ class ClosedLib[
       f.zoomCo(lib.output[A])
   }
 
-  def zapPremises[A, Ā, B, C](implicit ev: Dual[A, Ā]): ((A =⚬ B) |*| (Ā =⚬ C)) -⚬ (B |*| C) = {
+  def zapPremises[A, Ā, B, C](using ev: Dual[A, Ā]): ((A =⚬ B) |*| (Ā =⚬ C)) -⚬ (B |*| C) = {
     id                              [  (A =⚬ B) |*| (Ā =⚬ C)                ]
       .introSnd(ev.lInvert)      .to[ ((A =⚬ B) |*| (Ā =⚬ C)) |*| (Ā |*| A) ]
       .>.snd(swap)               .to[ ((A =⚬ B) |*| (Ā =⚬ C)) |*| (A |*| Ā) ]
@@ -78,7 +78,7 @@ class ClosedLib[
   /** Given `A` and `B` concurrently (`A |*| B`), we can suggest that `A` be consumed before `B`
     * by turning it into `Ā =⚬ B`, where `Ā` is the dual of `A`.
     */
-  def unveilSequentially[A, Ā, B](implicit ev: Dual[A, Ā]): (A |*| B) -⚬ (Ā =⚬ B) =
+  def unveilSequentially[A, Ā, B](using ev: Dual[A, Ā]): (A |*| B) -⚬ (Ā =⚬ B) =
     id[(A |*| B) |*| Ā]           .to[ (A |*|  B) |*| Ā  ]
       .assocLR                    .to[  A |*| (B  |*| Ā) ]
       .>.snd(swap)                .to[  A |*| (Ā  |*| B) ]

--- a/core/src/main/scala/libretto/CoreLib.scala
+++ b/core/src/main/scala/libretto/CoreLib.scala
@@ -2,7 +2,7 @@ package libretto
 
 import libretto.lambda.Category
 import libretto.lambda.util.SourcePos
-import libretto.util.unapply._
+import libretto.util.unapply.*
 import libretto.util.{Equal, ∀}
 import scala.annotation.tailrec
 
@@ -12,8 +12,8 @@ object CoreLib {
 }
 
 class CoreLib[DSL <: CoreDSL](val dsl: DSL) { lib =>
-  import dsl._
-  import dsl.$._
+  import dsl.*
+  import dsl.$.*
 
   val category: Category[-⚬] =
     new Category[-⚬] {
@@ -2290,7 +2290,7 @@ class CoreLib[DSL <: CoreDSL](val dsl: DSL) { lib =>
         .bimap(ifTrue, ifFalse)         .to[        B     |+|        C     ]
   }
 
-  import Bool._
+  import Bool.*
 
   def testBy[A, B, K: Cosemigroup: Junction.Positive](
     aKey: Getter[A, K],
@@ -2358,7 +2358,7 @@ class CoreLib[DSL <: CoreDSL](val dsl: DSL) { lib =>
       }
   }
 
-  import Compared._
+  import Compared.*
 
   def compareBy[A, B, K1 : CloseableCosemigroup : Junction.Positive, K2 : CloseableCosemigroup : Junction.Positive](
     aKey: Getter[A, K1],

--- a/core/src/main/scala/libretto/CrashDSL.scala
+++ b/core/src/main/scala/libretto/CrashDSL.scala
@@ -14,7 +14,7 @@ trait CrashDSL extends CoreDSL {
   def crashWhenDone[A, B](msg: String): (Done |*| A) -⚬ B
 
   private val lib = CoreLib(this)
-  import lib._
+  import lib.*
 
   def crashWhenNeed[A, B](msg: String): A -⚬ (Need |*| B) =
     introFst(lInvertSignal) > assocLR > snd(crashWhenDone(msg))

--- a/core/src/main/scala/libretto/Functor.scala
+++ b/core/src/main/scala/libretto/Functor.scala
@@ -35,7 +35,7 @@ object Functor {
 
   extension [->[_, _], F[_], A, B](f: A -> F[B])(using F: Functor[->, F]) {
     def >-[C](g: B -> C): A -> F[C] = {
-      import F.category._
+      import F.category.*
 
       f > F.lift(g)
     }

--- a/core/src/main/scala/libretto/InvertDSL.scala
+++ b/core/src/main/scala/libretto/InvertDSL.scala
@@ -72,7 +72,7 @@ trait InvertDSL extends ClosedDSL {
   def factorOutInversion[A, B]: (-[A] |*| -[B]) -⚬ -[A |*| B]
 
   private val coreLib = CoreLib(this)
-  import coreLib._
+  import coreLib.*
 
   override type =⚬[A, B] = -[A] |*| B
 
@@ -211,7 +211,7 @@ trait InvertDSL extends ClosedDSL {
   def unpackDemand[F[_]]: -[Rec[F]] -⚬ -[F[Rec[F]]] =
     contrapositive(pack[F])
 
-  import $._
+  import $.*
 
   extension [A](a: $[A]) {
     def supplyTo(out: $[-[A]])(using pos: SourcePos, ctx: LambdaContext): $[One] =

--- a/core/src/main/scala/libretto/InvertLib.scala
+++ b/core/src/main/scala/libretto/InvertLib.scala
@@ -14,8 +14,8 @@ class InvertLib[
 ](
   val coreLib: CoreLib,
 ) {
-  import coreLib.dsl._
-  import coreLib._
+  import coreLib.dsl.*
+  import coreLib.*
 
   def inversionDuality[A]: Dual[A, -[A]] =
     new Dual[A, -[A]] {

--- a/core/src/main/scala/libretto/InvertLib.scala
+++ b/core/src/main/scala/libretto/InvertLib.scala
@@ -23,14 +23,14 @@ class InvertLib[
       override val lInvert: One -⚬ (-[A] |*| A) = forevert[A]
     }
 
-  implicit val contraFunctorDemand: ContraFunctor[-] =
-    new ContraFunctor[-] {
-      override val category =
-        coreLib.category
+  // contraFunctorDemand
+  given ContraFunctor[-] with {
+    override val category =
+      coreLib.category
 
-      override def lift[A, B](f: A -⚬ B): -[B] -⚬ -[A] =
-        contrapositive(f)
-    }
+    override def lift[A, B](f: A -⚬ B): -[B] -⚬ -[A] =
+      contrapositive(f)
+  }
 
   extension (obj: Unlimited.type) {
     def pool[A](using Signaling.Positive[A]): LList1[A] -⚬ (Unlimited[A |*| -[A]] |*| LList1[A]) =

--- a/core/src/main/scala/libretto/Monad.scala
+++ b/core/src/main/scala/libretto/Monad.scala
@@ -5,7 +5,7 @@ trait Monad[->[_, _], F[_]] extends Functor[->, F] {
   def pure[A]    :       A -> F[A]
   def flatten[A] : F[F[A]] -> F[A]
 
-  import category._
+  import category.*
 
   def liftF[A, B](f: A -> F[B]): F[A] -> F[B] =
     lift(f) > flatten

--- a/core/src/main/scala/libretto/TimerDSL.scala
+++ b/core/src/main/scala/libretto/TimerDSL.scala
@@ -6,7 +6,7 @@ trait TimerDSL extends CoreDSL {
   def delay(d: FiniteDuration): Done -⚬ Done
 
   private val lib = CoreLib(this)
-  import lib._
+  import lib.*
 
   def delayNeed(d: FiniteDuration): Need -⚬ Need = {
     id                           [                      Need  ]

--- a/core/src/main/scala/libretto/scaletto/Scaletto.scala
+++ b/core/src/main/scala/libretto/scaletto/Scaletto.scala
@@ -70,7 +70,7 @@ trait Scaletto extends TimerDSL with CrashDSL with InvertDSL {
   }
 
   private val lib = CoreLib(this)
-  import lib._
+  import lib.*
 
   /** Creates an entangled pair of demand ([[Neg]]) and supply ([[Val]]) such that when the demand is fulfilled
     * with a value, that value will be produced by the supply.

--- a/core/src/main/scala/libretto/scaletto/ScalettoLib.scala
+++ b/core/src/main/scala/libretto/scaletto/ScalettoLib.scala
@@ -5,7 +5,7 @@ import libretto.{CoreLib, InvertLib}
 import libretto.lambda.util.SourcePos
 import libretto.util.Async
 import scala.annotation.targetName
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.reflect.TypeTest
 import scala.util.Random
 
@@ -25,12 +25,12 @@ class ScalettoLib[
   val dsl: DSL,
   val coreLib: CoreLib with libretto.CoreLib[dsl.type],
 ) {
-  import dsl._
-  import dsl.$._
-  import coreLib._
+  import dsl.*
+  import dsl.$.*
+  import coreLib.*
 
   private val invertLib = InvertLib(coreLib)
-  import invertLib._
+  import invertLib.*
 
   object Val {
     def isEq[A](a: A): Val[A] -⚬ (Val[a.type] |+| Val[A]) =
@@ -279,7 +279,7 @@ class ScalettoLib[
     lteqBy(aKey, bKey).>.right(swap)
 
   given [A : Ordering]: Comparable[Val[A], Val[A]] with {
-    import coreLib.given, Compared._, Either as ⊻
+    import coreLib.given, Compared.*, Either as ⊻
 
     private val scalaCompare: ((A, A)) => ((A, A) ⊻ ((A, A) ⊻ (A, A))) =
       { (a1, a2) =>

--- a/core/src/main/scala/libretto/scaletto/StarterAppBase.scala
+++ b/core/src/main/scala/libretto/scaletto/StarterAppBase.scala
@@ -1,6 +1,6 @@
 package libretto.scaletto
 
 abstract class StarterAppBase {
-  export StarterKit._
+  export StarterKit.*
   export StarterKit.scalettoLib.given
 }

--- a/core/src/main/scala/libretto/scaletto/StarterAppBase.scala
+++ b/core/src/main/scala/libretto/scaletto/StarterAppBase.scala
@@ -2,4 +2,5 @@ package libretto.scaletto
 
 abstract class StarterAppBase {
   export StarterKit._
+  export StarterKit.scalettoLib.given
 }

--- a/core/src/main/scala/libretto/scaletto/StarterKit.scala
+++ b/core/src/main/scala/libretto/scaletto/StarterKit.scala
@@ -41,11 +41,11 @@ abstract class AbstractStarterKit(
   ): ScalettoExecutor.Of[dsl.type, bridge.type] =
     executor0(scheduler, blockingExecutor)
 
-  export dsl._
-  export coreLib.{dsl => _, _}
-  export scalettoLib.{dsl => _, coreLib => _, _, given}
-  export closedLib.{dsl => _, coreLib => _, _}
-  export invertLib.{coreLib => _, _}
+  export dsl.*
+  export coreLib.{dsl => _, *}
+  export scalettoLib.{dsl => _, coreLib => _, *, given}
+  export closedLib.{dsl => _, coreLib => _, *}
+  export invertLib.{coreLib => _, *}
 
   def runScalaAsync[A](blueprint: Done -⚬ Val[A]): Future[A] = {
     val mainExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime.availableProcessors())

--- a/core/src/main/scala/libretto/scaletto/StarterKit.scala
+++ b/core/src/main/scala/libretto/scaletto/StarterKit.scala
@@ -7,6 +7,7 @@ import libretto.scaletto.impl.futurebased.{BridgeImpl, FutureExecutor}
 import libretto.util.Async
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContextExecutor
 
 object StarterKit extends StarterKit
 
@@ -35,7 +36,7 @@ abstract class AbstractStarterKit(
   val invertLib: InvertLib[coreLib.type] =
     InvertLib(coreLib)
 
-  def executor(blockingExecutor: JExecutor)(implicit
+  def executor(blockingExecutor: JExecutor)(
     scheduler: ScheduledExecutorService,
   ): ScalettoExecutor.Of[dsl.type, bridge.type] =
     executor0(scheduler, blockingExecutor)
@@ -49,7 +50,7 @@ abstract class AbstractStarterKit(
   def runScalaAsync[A](blueprint: Done -⚬ Val[A]): Future[A] = {
     val mainExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime.availableProcessors())
     val blockingExecutor = Executors.newCachedThreadPool()
-    implicit val ec = ExecutionContext.fromExecutor(mainExecutor)
+    given ExecutionContextExecutor = ExecutionContext.fromExecutor(mainExecutor)
     val exec = executor(blockingExecutor)(mainExecutor)
 
     val executing = exec.execute(blueprint)

--- a/core/src/main/scala/libretto/scaletto/impl/FreeScaletto.scala
+++ b/core/src/main/scala/libretto/scaletto/impl/FreeScaletto.scala
@@ -149,7 +149,7 @@ abstract class FreeScaletto {
 }
 
 object FreeScaletto extends FreeScaletto with Scaletto {
-  import -⚬._
+  import -⚬.*
 
   override type ->[A, B] = A -⚬ B
 

--- a/core/src/main/scala/libretto/scaletto/impl/FreeScaletto.scala
+++ b/core/src/main/scala/libretto/scaletto/impl/FreeScaletto.scala
@@ -38,11 +38,11 @@ abstract class FreeScaletto {
   final class Res[A] private()
   final type UInt31 = Val[Int]
 
-  implicit val biInjectivePair: BiInjective[|*|] =
-    new BiInjective[|*|] {
-      override def unapply[A, B, X, Y](ev: (A |*| B) =:= (X |*| Y)): (A =:= X, B =:= Y) =
-        ev match { case TypeEq(Refl()) => (summon, summon) }
-    }
+  // biInjectivePair
+  given BiInjective[|*|] with {
+    override def unapply[A, B, X, Y](ev: (A |*| B) =:= (X |*| Y)): (A =:= X, B =:= Y) =
+      ev match { case TypeEq(Refl()) => (summon, summon) }
+  }
 
   object -⚬ {
     case class Id[A]() extends (A -⚬ A)
@@ -457,21 +457,20 @@ object FreeScaletto extends FreeScaletto with Scaletto {
       id
   }
 
-  implicit val csmc: ClosedSymmetricMonoidalCategory[-⚬, |*|, One, =⚬] =
-    new ClosedSymmetricMonoidalCategory[-⚬, |*|, One, =⚬] {
-      override def andThen[A, B, C](f: A -⚬ B, g: B -⚬ C): A -⚬ C                              = FreeScaletto.this.andThen(f, g)
-      override def id[A]: A -⚬ A                                                               = FreeScaletto.this.id[A]
-      override def par[A1, A2, B1, B2](f1: A1 -⚬ B1, f2: A2 -⚬ B2): (A1 |*| A2) -⚬ (B1 |*| B2) = FreeScaletto.this.par(f1, f2)
-      override def assocLR[A, B, C]: ((A |*| B) |*| C) -⚬ (A |*| (B |*| C))                    = FreeScaletto.this.assocLR[A, B, C]
-      override def assocRL[A, B, C]: (A |*| (B |*| C)) -⚬ ((A |*| B) |*| C)                    = FreeScaletto.this.assocRL[A, B, C]
-      override def swap[A, B]: (A |*| B) -⚬ (B |*| A)                                          = FreeScaletto.this.swap[A, B]
-      override def elimFst[A]: (One |*| A) -⚬ A                                                = FreeScaletto.this.elimFst[A]
-      override def elimSnd[A]: (A |*| One) -⚬ A                                                = FreeScaletto.this.elimSnd[A]
-      override def introFst[A]: A -⚬ (One |*| A)                                               = FreeScaletto.this.introFst[A]
-      override def introSnd[A]: A -⚬ (A |*| One)                                               = FreeScaletto.this.introSnd[A]
-      override def curry[A, B, C](f: (A |*| B) -⚬ C): A -⚬ (B =⚬ C)                            = FreeScaletto.this.curry(f)
-      override def eval[A, B]: ((A =⚬ B) |*| A) -⚬ B                                           = FreeScaletto.this.eval[A, B]
-    }
+  given ℭ: ClosedSymmetricMonoidalCategory[-⚬, |*|, One, =⚬] with {
+    override def andThen[A, B, C](f: A -⚬ B, g: B -⚬ C): A -⚬ C                              = FreeScaletto.this.andThen(f, g)
+    override def id[A]: A -⚬ A                                                               = FreeScaletto.this.id[A]
+    override def par[A1, A2, B1, B2](f1: A1 -⚬ B1, f2: A2 -⚬ B2): (A1 |*| A2) -⚬ (B1 |*| B2) = FreeScaletto.this.par(f1, f2)
+    override def assocLR[A, B, C]: ((A |*| B) |*| C) -⚬ (A |*| (B |*| C))                    = FreeScaletto.this.assocLR[A, B, C]
+    override def assocRL[A, B, C]: (A |*| (B |*| C)) -⚬ ((A |*| B) |*| C)                    = FreeScaletto.this.assocRL[A, B, C]
+    override def swap[A, B]: (A |*| B) -⚬ (B |*| A)                                          = FreeScaletto.this.swap[A, B]
+    override def elimFst[A]: (One |*| A) -⚬ A                                                = FreeScaletto.this.elimFst[A]
+    override def elimSnd[A]: (A |*| One) -⚬ A                                                = FreeScaletto.this.elimSnd[A]
+    override def introFst[A]: A -⚬ (One |*| A)                                               = FreeScaletto.this.introFst[A]
+    override def introSnd[A]: A -⚬ (A |*| One)                                               = FreeScaletto.this.introSnd[A]
+    override def curry[A, B, C](f: (A |*| B) -⚬ C): A -⚬ (B =⚬ C)                            = FreeScaletto.this.curry(f)
+    override def eval[A, B]: ((A =⚬ B) |*| A) -⚬ B                                           = FreeScaletto.this.eval[A, B]
+  }
 
   type Var[A] = libretto.lambda.Var[VarOrigin, A]
 
@@ -594,10 +593,10 @@ object FreeScaletto extends FreeScaletto with Scaletto {
 
       lambdas.absNested[A, B](bindVar, f) match {
         case Closure(captured, f) =>
-          (zipExprs(captured) map csmc.curry(f.fold))(resultVar)
+          (zipExprs(captured) map ℭ.curry(f.fold))(resultVar)
         case Exact(f) =>
           val captured0 = $.one(using pos)
-          (captured0 map csmc.curry(elimFst > f.fold))(resultVar)
+          (captured0 map ℭ.curry(elimFst > f.fold))(resultVar)
         case Failure(e) =>
           raiseError(e)
       }

--- a/core/src/main/scala/libretto/scaletto/impl/VarOrigin.scala
+++ b/core/src/main/scala/libretto/scaletto/impl/VarOrigin.scala
@@ -3,7 +3,7 @@ package libretto.scaletto.impl
 import libretto.lambda.util.SourcePos
 
 sealed trait VarOrigin {
-  import VarOrigin._
+  import VarOrigin.*
 
   def print: String =
     this match {

--- a/core/src/main/scala/libretto/scaletto/impl/futurebased/ExecutionImpl.scala
+++ b/core/src/main/scala/libretto/scaletto/impl/futurebased/ExecutionImpl.scala
@@ -17,10 +17,10 @@ private class ExecutionImpl(
   ec: ExecutionContext,
   scheduler: Scheduler,
 ) extends ScalettoExecution[FreeScaletto.type] {
-  import ResourceRegistry._
+  import ResourceRegistry.*
 
   override val dsl = FreeScaletto
-  import dsl._
+  import dsl.*
 
   override opaque type OutPort[A] = Frontier[A]
   override opaque type InPort[A] = Frontier[A] => Unit
@@ -227,7 +227,7 @@ private class ExecutionImpl(
     }
 
   private sealed trait Frontier[A] {
-    import Frontier._
+    import Frontier.*
 
     def extendBy[B](f: A -⚬ B)(using
       resourceRegistry: ResourceRegistry,

--- a/core/src/main/scala/libretto/scaletto/impl/futurebased/ExecutionImpl.scala
+++ b/core/src/main/scala/libretto/scaletto/impl/futurebased/ExecutionImpl.scala
@@ -241,7 +241,7 @@ private class ExecutionImpl(
       ec: ExecutionContext,
       scheduler: Scheduler,
     ): Frontier[B] = {
-      implicit class FrontierOps[X](fx: Frontier[X]) {
+      extension [X](fx: Frontier[X]) {
         def extend[Y](f: X -⚬ Y): Frontier[Y] =
           if (depth < 100)
             fx.extendBy(f, depth + 1)
@@ -1157,8 +1157,7 @@ private class ExecutionImpl(
         }
     }
 
-    // using implicit class because extension methods may not have type parameters
-    implicit class FrontierValOps[A](f: Frontier[Val[A]]) {
+    extension [A](f: Frontier[Val[A]]) {
       def mapVal[B](g: A => B)(using ExecutionContext): Frontier[Val[B]] =
         f match {
           case Value(a) => Value(g(a))

--- a/core/src/main/scala/libretto/scaletto/impl/futurebased/ResourceRegistry.scala
+++ b/core/src/main/scala/libretto/scaletto/impl/futurebased/ResourceRegistry.scala
@@ -5,7 +5,7 @@ import libretto.util.Async
 import scala.collection.mutable
 
 private class ResourceRegistry {
-  import ResourceRegistry._
+  import ResourceRegistry.*
 
   // negative value indicates registry closed
   private var lastResId: Long =

--- a/core/src/main/scala/libretto/util/Async.scala
+++ b/core/src/main/scala/libretto/util/Async.scala
@@ -3,7 +3,7 @@ package libretto.util
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.function.BinaryOperator
-import libretto.util.atomic._
+import libretto.util.atomic.*
 import scala.annotation.tailrec
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.concurrent.duration.FiniteDuration
@@ -68,7 +68,7 @@ object Async {
       case Listener(listener: A => Unit)
       case Done()
     }
-    import State._
+    import State.*
 
     val ref =
       new AtomicReference[State[A]](State.Initial())
@@ -130,7 +130,7 @@ object Async {
       case class SingleListener(listener: A => Unit) extends Listening[A]
       case class Listeners[A](head: A => Unit, tail: Listening[A]) extends Listening[A]
     }
-    import State._
+    import State.*
 
     val ref =
       new AtomicReference[State[A]](State.Initial())

--- a/core/src/main/scala/libretto/util/unapply.scala
+++ b/core/src/main/scala/libretto/util/unapply.scala
@@ -7,11 +7,10 @@ object unapply {
   }
 
   object Unapply {
-    implicit def unapplyInstance[F[_], X]: Unapply[F[X], F] { type A = X } =
-      new Unapply[F[X], F] {
-        type A = X
-        val ev: F[X] =:= F[A] = implicitly
-      }
+    given [F[_], X]: Unapply[F[X], F] with {
+      type A = X
+      val ev: F[X] =:= F[A] = summon
+    }
   }
 
   trait Unapply2[FAB, F[_, _]] {
@@ -21,11 +20,10 @@ object unapply {
   }
 
   object Unapply2 {
-    implicit def unapply2Instance[F[_, _], X, Y]: Unapply2[F[X, Y], F] { type A = X; type B = Y } =
-      new Unapply2[F[X, Y], F] {
-        type A = X
-        type B = Y
-        val ev: F[X, Y] =:= F[A, B] = implicitly
-      }
+    given [F[_, _], X, Y]: Unapply2[F[X, Y], F] with {
+      type A = X
+      type B = Y
+      val ev: F[X, Y] =:= F[A, B] = summon
+    }
   }
 }

--- a/examples/src/main/scala/libretto/examples/CoffeeMachine.scala
+++ b/examples/src/main/scala/libretto/examples/CoffeeMachine.scala
@@ -2,7 +2,7 @@ package libretto.examples
 
 import libretto.scaletto.StarterApp
 import libretto.scaletto.StarterKit.scalettoLib.given
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object CoffeeMachine extends StarterApp { app =>
 

--- a/examples/src/main/scala/libretto/examples/CoffeeMachine.scala
+++ b/examples/src/main/scala/libretto/examples/CoffeeMachine.scala
@@ -1,6 +1,7 @@
 package libretto.examples
 
 import libretto.scaletto.StarterApp
+import libretto.scaletto.StarterKit.scalettoLib.given
 import scala.concurrent.duration._
 
 object CoffeeMachine extends StarterApp { app =>

--- a/examples/src/main/scala/libretto/examples/PingPongN.scala
+++ b/examples/src/main/scala/libretto/examples/PingPongN.scala
@@ -1,7 +1,7 @@
 package libretto.examples
 
 import libretto.scaletto.StarterApp
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
  * This example implements interaction between two parties, Alice and Bob, in which

--- a/examples/src/main/scala/libretto/examples/PoolingMicroscopes.scala
+++ b/examples/src/main/scala/libretto/examples/PoolingMicroscopes.scala
@@ -34,7 +34,8 @@ object PoolingMicroscopes extends StarterApp {
           .>(assocLR > elimSnd(backvert))   .to[    Done                                    ]
     }
 
-    implicit def signalMicroscopeReadiness: Signaling.Positive[Microscope] =
+    // signalMicroscopeReadiness
+    given Signaling.Positive[Microscope] =
       signalingVal
   }
   import Microscopes._

--- a/examples/src/main/scala/libretto/examples/PoolingMicroscopes.scala
+++ b/examples/src/main/scala/libretto/examples/PoolingMicroscopes.scala
@@ -1,7 +1,7 @@
 package libretto.examples
 
 import libretto.scaletto.StarterApp
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
  * N scientists sharing M microscopes (N > M).
@@ -38,7 +38,7 @@ object PoolingMicroscopes extends StarterApp {
     given Signaling.Positive[Microscope] =
       signalingVal
   }
-  import Microscopes._
+  import Microscopes.*
 
   def doExperiment(
     scientistName: String,

--- a/examples/src/main/scala/libretto/examples/canteen/Customer.scala
+++ b/examples/src/main/scala/libretto/examples/canteen/Customer.scala
@@ -1,9 +1,9 @@
 package libretto.examples.canteen
 
-import libretto.examples.canteen.Protocol._
-import libretto.scaletto.StarterKit._
-import libretto.scaletto.StarterKit.$._
-import libretto.scaletto.StarterKit.coreLib._
+import libretto.examples.canteen.Protocol.*
+import libretto.scaletto.StarterKit.*
+import libretto.scaletto.StarterKit.$.*
+import libretto.scaletto.StarterKit.coreLib.*
 
 object Customer {
 

--- a/examples/src/main/scala/libretto/examples/canteen/Main.scala
+++ b/examples/src/main/scala/libretto/examples/canteen/Main.scala
@@ -1,9 +1,9 @@
 package libretto.examples.canteen
 
-import libretto.examples.canteen.Protocol._
+import libretto.examples.canteen.Protocol.*
 import libretto.scaletto.StarterApp
-import libretto.scaletto.StarterKit._
-import libretto.scaletto.StarterKit.$._
+import libretto.scaletto.StarterKit.*
+import libretto.scaletto.StarterKit.$.*
 
 object Main extends StarterApp {
 

--- a/examples/src/main/scala/libretto/examples/canteen/Protocol.scala
+++ b/examples/src/main/scala/libretto/examples/canteen/Protocol.scala
@@ -2,6 +2,7 @@ package libretto.examples.canteen
 
 import libretto.scaletto.StarterKit._
 import libretto.scaletto.StarterKit.$._
+import libretto.scaletto.StarterKit.scalettoLib.given
 
 object Protocol {
   /** Interface of a canteen for one session.

--- a/examples/src/main/scala/libretto/examples/canteen/Protocol.scala
+++ b/examples/src/main/scala/libretto/examples/canteen/Protocol.scala
@@ -1,7 +1,7 @@
 package libretto.examples.canteen
 
-import libretto.scaletto.StarterKit._
-import libretto.scaletto.StarterKit.$._
+import libretto.scaletto.StarterKit.*
+import libretto.scaletto.StarterKit.$.*
 import libretto.scaletto.StarterKit.scalettoLib.given
 
 object Protocol {

--- a/examples/src/main/scala/libretto/examples/canteen/Provider.scala
+++ b/examples/src/main/scala/libretto/examples/canteen/Provider.scala
@@ -1,8 +1,8 @@
 package libretto.examples.canteen
 
-import libretto.examples.canteen.Protocol._
-import libretto.scaletto.StarterKit._
-import libretto.scaletto.StarterKit.$._
+import libretto.examples.canteen.Protocol.*
+import libretto.scaletto.StarterKit.*
+import libretto.scaletto.StarterKit.$.*
 
 /** A simplistic canteen facility that serves only one customer and prepares everything on demand. */
 object Provider {

--- a/examples/src/main/scala/libretto/examples/coffeemachine/CoffeeMachineClient.scala
+++ b/examples/src/main/scala/libretto/examples/coffeemachine/CoffeeMachineClient.scala
@@ -1,14 +1,14 @@
 package libretto.examples.coffeemachine
 
-import libretto.scaletto.StarterKit._
-import scala.concurrent.duration._
+import libretto.scaletto.StarterKit.*
+import scala.concurrent.duration.*
 
 /**
  * A front panel of a coffee machine. Displays the menu and prompts the user for choices.
  */
 object CoffeeMachineClient {
-  import Protocol._
-  import $._
+  import Protocol.*
+  import $.*
 
   val useCoffeeMachine: CoffeeMachine -⚬ Done = {
     def go: (Done |*| CoffeeMachine) -⚬ Done = rec { repeat =>

--- a/examples/src/main/scala/libretto/examples/coffeemachine/CoffeeMachineProvider.scala
+++ b/examples/src/main/scala/libretto/examples/coffeemachine/CoffeeMachineProvider.scala
@@ -2,6 +2,7 @@ package libretto.examples.coffeemachine
 
 import libretto.scaletto.StarterKit
 import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.scalettoLib.given
 
 object CoffeeMachineProvider {
   import Protocol._

--- a/examples/src/main/scala/libretto/examples/coffeemachine/CoffeeMachineProvider.scala
+++ b/examples/src/main/scala/libretto/examples/coffeemachine/CoffeeMachineProvider.scala
@@ -1,12 +1,12 @@
 package libretto.examples.coffeemachine
 
 import libretto.scaletto.StarterKit
-import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.*
 import libretto.scaletto.StarterKit.scalettoLib.given
 
 object CoffeeMachineProvider {
-  import Protocol._
-  import $._
+  import Protocol.*
+  import $.*
 
   val makeCoffeeMachine: Done -⚬ CoffeeMachine = rec { self =>
     val returnAndRepeat: Val[Beverage] -⚬ (Val[Beverage] |*| CoffeeMachine) =

--- a/examples/src/main/scala/libretto/examples/coffeemachine/Protocol.scala
+++ b/examples/src/main/scala/libretto/examples/coffeemachine/Protocol.scala
@@ -1,7 +1,7 @@
 package libretto.examples.coffeemachine
 
 import libretto.scaletto.StarterKit.dsl
-import libretto.scaletto.StarterKit.dsl._
+import libretto.scaletto.StarterKit.dsl.*
 
 object Protocol {
 

--- a/examples/src/main/scala/libretto/examples/diningPhilosophers/DiningPhilosophers.scala
+++ b/examples/src/main/scala/libretto/examples/diningPhilosophers/DiningPhilosophers.scala
@@ -3,7 +3,7 @@ package libretto.examples.diningPhilosophers
 import libretto.scaletto.StarterApp
 
 object DiningPhilosophers extends StarterApp {
-  import $._
+  import $.*
 
   val philosophers = Philosophers(ForksProvider)
   import philosophers.{behavior => philosopher}

--- a/examples/src/main/scala/libretto/examples/diningPhilosophers/Forks.scala
+++ b/examples/src/main/scala/libretto/examples/diningPhilosophers/Forks.scala
@@ -33,5 +33,5 @@ trait Forks {
     *  - signal readiness (when picked up or done being used).
     *  - defer readiness by awaiting a [[Done]] signal.
     */
-  implicit def heldForkReadiness: SignalingJunction.Positive[HeldFork]
+  given heldForkReadiness: SignalingJunction.Positive[HeldFork]
 }

--- a/examples/src/main/scala/libretto/examples/diningPhilosophers/Forks.scala
+++ b/examples/src/main/scala/libretto/examples/diningPhilosophers/Forks.scala
@@ -1,7 +1,7 @@
 package libretto.examples.diningPhilosophers
 
-import libretto.scaletto.StarterKit._
-import libretto.scaletto.StarterKit.$._
+import libretto.scaletto.StarterKit.*
+import libretto.scaletto.StarterKit.$.*
 
 trait Forks {
   /** Interface to a fork. The fork itself may be shared among multiple philosophers,

--- a/examples/src/main/scala/libretto/examples/diningPhilosophers/ForksProvider.scala
+++ b/examples/src/main/scala/libretto/examples/diningPhilosophers/ForksProvider.scala
@@ -1,7 +1,7 @@
 package libretto.examples.diningPhilosophers
 
-import libretto.scaletto.StarterKit._
-import libretto.scaletto.StarterKit.$._
+import libretto.scaletto.StarterKit.*
+import libretto.scaletto.StarterKit.$.*
 
 /** Implements `Forks`.
   * Internally, it represents a fork as a lock from the core library.

--- a/examples/src/main/scala/libretto/examples/diningPhilosophers/Philosophers.scala
+++ b/examples/src/main/scala/libretto/examples/diningPhilosophers/Philosophers.scala
@@ -1,8 +1,8 @@
 package libretto.examples.diningPhilosophers
 
-import libretto.scaletto.StarterKit._
-import libretto.scaletto.StarterKit.$._
-import scala.concurrent.duration._
+import libretto.scaletto.StarterKit.*
+import libretto.scaletto.StarterKit.$.*
+import scala.concurrent.duration.*
 import scala.util.Random
 
 object Philosophers {
@@ -11,7 +11,7 @@ object Philosophers {
 }
 
 class Philosophers[ForksImpl <: Forks](val forks: ForksImpl) {
-  import forks._
+  import forks.*
 
   /** A philosopher is given access to two shared forks (each of them shared with one neighbor).
     * When a philosopher finishes, it produces a [[Done]] signal.

--- a/examples/src/main/scala/libretto/examples/dogTreatsFactory/DogTreatsFactory.scala
+++ b/examples/src/main/scala/libretto/examples/dogTreatsFactory/DogTreatsFactory.scala
@@ -1,6 +1,6 @@
 package libretto.examples.dogTreatsFactory
 
-import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.*
 import libretto.stream.scaletto.DefaultStreams.ValSource
 
 object DogTreatsFactory {

--- a/examples/src/main/scala/libretto/examples/dogTreatsFactory/Main.scala
+++ b/examples/src/main/scala/libretto/examples/dogTreatsFactory/Main.scala
@@ -4,7 +4,7 @@ import libretto.scaletto.StarterApp
 import libretto.stream.scaletto.DefaultStreams.ValSource
 
 object Main extends StarterApp {
-  import $._
+  import $.*
   import scalettoLib.printLine
 
   val nLargeBones = 20

--- a/examples/src/main/scala/libretto/examples/interactionNets/unaryArithmetic/package.scala
+++ b/examples/src/main/scala/libretto/examples/interactionNets/unaryArithmetic/package.scala
@@ -1,6 +1,6 @@
 package libretto.examples.interactionNets.unaryArithmetic
 
-import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.*
 import libretto.scaletto.StarterKit.scalettoLib.given
 import libretto.lambda.util.SourcePos
 

--- a/examples/src/main/scala/libretto/examples/libraryOfAlexandria/ConnectorModule.scala
+++ b/examples/src/main/scala/libretto/examples/libraryOfAlexandria/ConnectorModule.scala
@@ -1,7 +1,7 @@
 package libretto.examples.libraryOfAlexandria
 
-import libretto.scaletto.StarterKit._
-import libretto.stream.scaletto.DefaultStreams._
+import libretto.scaletto.StarterKit.*
+import libretto.stream.scaletto.DefaultStreams.*
 
 import vendor.{Page, ScrollId}
 

--- a/examples/src/main/scala/libretto/examples/libraryOfAlexandria/ConnectorModuleImpl.scala
+++ b/examples/src/main/scala/libretto/examples/libraryOfAlexandria/ConnectorModuleImpl.scala
@@ -1,7 +1,7 @@
 package libretto.examples.libraryOfAlexandria
 
-import libretto.scaletto.StarterKit._
-import libretto.stream.scaletto.DefaultStreams._
+import libretto.scaletto.StarterKit.*
+import libretto.stream.scaletto.DefaultStreams.*
 
 import vendor.{Page, ScrollId}
 

--- a/examples/src/main/scala/libretto/examples/libraryOfAlexandria/Downloader.scala
+++ b/examples/src/main/scala/libretto/examples/libraryOfAlexandria/Downloader.scala
@@ -1,7 +1,7 @@
 package libretto.examples.libraryOfAlexandria
 
-import libretto.scaletto.StarterKit._
-import libretto.stream.scaletto.DefaultStreams._
+import libretto.scaletto.StarterKit.*
+import libretto.stream.scaletto.DefaultStreams.*
 
 import vendor.{Page, ScrollId}
 

--- a/examples/src/main/scala/libretto/examples/libraryOfAlexandria/Main.scala
+++ b/examples/src/main/scala/libretto/examples/libraryOfAlexandria/Main.scala
@@ -1,8 +1,8 @@
 package libretto.examples.libraryOfAlexandria
 
 import libretto.scaletto.StarterApp
-import libretto.scaletto.StarterKit._
-import libretto.stream.scaletto.DefaultStreams._
+import libretto.scaletto.StarterKit.*
+import libretto.stream.scaletto.DefaultStreams.*
 
 import vendor.{Page, ScrollId}
 

--- a/examples/src/main/scala/libretto/examples/santa/solution1/SantaClaus.scala
+++ b/examples/src/main/scala/libretto/examples/santa/solution1/SantaClaus.scala
@@ -1,7 +1,7 @@
 package libretto.examples.santa.solution1
 
 import libretto.scaletto.StarterApp
-import libretto.scaletto.StarterKit.{_, given}
+import libretto.scaletto.StarterKit.{*, given}
 import libretto.scaletto.StarterKit.Endless.{groupMap, mapSequentially, mergeEitherPreferred, take}
 import libretto.scaletto.StarterKit.LList1.{closeAll, eachNotifyBy, foldMap, map, sortBySignal, transform, unzipBy}
 import libretto.scaletto.StarterKit.Monoid.given

--- a/examples/src/main/scala/libretto/examples/santa/solution1/SantaClaus.scala
+++ b/examples/src/main/scala/libretto/examples/santa/solution1/SantaClaus.scala
@@ -4,7 +4,7 @@ import libretto.scaletto.StarterApp
 import libretto.scaletto.StarterKit.{_, given}
 import libretto.scaletto.StarterKit.Endless.{groupMap, mapSequentially, mergeEitherPreferred, take}
 import libretto.scaletto.StarterKit.LList1.{closeAll, eachNotifyBy, foldMap, map, sortBySignal, transform, unzipBy}
-import libretto.scaletto.StarterKit.Monoid.monoidOne
+import libretto.scaletto.StarterKit.Monoid.given
 import scala.{:: => NonEmptyList}
 
 object SantaClaus extends StarterApp {

--- a/examples/src/main/scala/libretto/examples/santa/solution2/SantaClaus.scala
+++ b/examples/src/main/scala/libretto/examples/santa/solution2/SantaClaus.scala
@@ -1,7 +1,7 @@
 package libretto.examples.santa.solution2
 
 import libretto.scaletto.StarterApp
-import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.*
 import libretto.stream.scaletto.DefaultStreams.Source
 import scala.{:: => NonEmptyList}
 

--- a/examples/src/main/scala/libretto/examples/sunflowers/SunflowerProcessingFacility.scala
+++ b/examples/src/main/scala/libretto/examples/sunflowers/SunflowerProcessingFacility.scala
@@ -1,6 +1,6 @@
 package libretto.examples.sunflowers
 
-import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.*
 import libretto.stream.scaletto.DefaultStreams.ValSource
 import libretto.stream.scaletto.DefaultStreams.ValSource.{Polled, fromChoice, notifyAction, poll}
 

--- a/examples/src/main/scala/libretto/examples/supermarket/Customers.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/Customers.scala
@@ -1,8 +1,8 @@
 package libretto.examples.supermarket
 
-import libretto.scaletto.StarterKit._
-import libretto.examples.supermarket.money._
-import scala.concurrent.duration._
+import libretto.scaletto.StarterKit.*
+import libretto.examples.supermarket.money.*
+import scala.concurrent.duration.*
 
 object Customers {
   def apply(supermarket: SupermarketInterface): Customers[supermarket.type] =
@@ -12,9 +12,9 @@ object Customers {
 class Customers[SupermarketImpl <: SupermarketInterface](
   val supermarket: SupermarketImpl,
 ) {
-  import libretto.scaletto.StarterKit.$._
-  import supermarket.{_, given}
-  import supermarket.goods._
+  import libretto.scaletto.StarterKit.$.*
+  import supermarket.{*, given}
+  import supermarket.goods.*
 
   /** Blueprint for customer behavior. A customer gets access to a supermarket and runs to completion ([[Done]]). */
   def behavior(who: String): Supermarket -⚬ Done = {

--- a/examples/src/main/scala/libretto/examples/supermarket/Customers.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/Customers.scala
@@ -13,7 +13,7 @@ class Customers[SupermarketImpl <: SupermarketInterface](
   val supermarket: SupermarketImpl,
 ) {
   import libretto.scaletto.StarterKit.$._
-  import supermarket._
+  import supermarket.{_, given}
   import supermarket.goods._
 
   /** Blueprint for customer behavior. A customer gets access to a supermarket and runs to completion ([[Done]]). */

--- a/examples/src/main/scala/libretto/examples/supermarket/Supermarket.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/Supermarket.scala
@@ -23,7 +23,7 @@ import libretto.scaletto.StarterApp
  *    - the type `Shopping` is a protocol between the store and the customer
  */
 object Supermarket extends StarterApp {
-  import $._
+  import $.*
   import money.CoinBank
   import SupermarketProvider.Supermarket
 

--- a/examples/src/main/scala/libretto/examples/supermarket/SupermarketInterface.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/SupermarketInterface.scala
@@ -11,8 +11,8 @@ trait SupermarketInterface {
 
   import goods.{Beer, ToiletPaper}
 
-  implicit def comonoidSupermarket: Comonoid[Supermarket]
-  implicit def basketReadiness[Items]: Signaling.Positive[Shopping[Items]]
+  given comonoidSupermarket: Comonoid[Supermarket]
+  given basketReadiness[Items]: Signaling.Positive[Shopping[Items]]
 
   def enterAndObtainBasket: Supermarket -⚬ Shopping[One]
 

--- a/examples/src/main/scala/libretto/examples/supermarket/SupermarketInterface.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/SupermarketInterface.scala
@@ -1,7 +1,7 @@
 package libretto.examples.supermarket
 
-import libretto.scaletto.StarterKit._
-import libretto.examples.supermarket.money._
+import libretto.scaletto.StarterKit.*
+import libretto.examples.supermarket.money.*
 
 trait SupermarketInterface {
   type Supermarket

--- a/examples/src/main/scala/libretto/examples/supermarket/SupermarketProvider.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/SupermarketProvider.scala
@@ -1,15 +1,15 @@
 package libretto.examples.supermarket
 
-import libretto.scaletto.StarterKit._
-import libretto.examples.supermarket.baskets._
-import libretto.examples.supermarket.money._
-import scala.concurrent.duration._
+import libretto.scaletto.StarterKit.*
+import libretto.examples.supermarket.baskets.*
+import libretto.examples.supermarket.money.*
+import scala.concurrent.duration.*
 
 object SupermarketProvider extends SupermarketInterface {
-  import libretto.scaletto.StarterKit.$._
+  import libretto.scaletto.StarterKit.$.*
 
   override val goods: Goods.type = Goods
-  import goods._
+  import goods.*
 
   private type BorrowedBasket = Basket |*| -[Basket]
   private type ItemSelection = Beer |&| ToiletPaper

--- a/examples/src/main/scala/libretto/examples/supermarket/SupermarketProvider.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/SupermarketProvider.scala
@@ -22,11 +22,11 @@ object SupermarketProvider extends SupermarketInterface {
   override opaque type Supermarket =
     Unlimited[Shopping[One]]
 
-  override implicit def comonoidSupermarket: Comonoid[Supermarket] =
+  override given comonoidSupermarket: Comonoid[Supermarket] =
     Unlimited.comonoidUnlimited
 
-  override def basketReadiness[Items]: Signaling.Positive[Shopping[Items]] =
-    Signaling.Positive.bySnd(Signaling.Positive.byFst(signalingJunctionBorrowedBasket))
+  override given basketReadiness[Items]: Signaling.Positive[Shopping[Items]] =
+    Signaling.Positive.bySnd(using Signaling.Positive.byFst(using signalingJunctionBorrowedBasket))
 
   override def enterAndObtainBasket: Supermarket -⚬ Shopping[One] =
     λ { supermarket =>
@@ -72,7 +72,7 @@ object SupermarketProvider extends SupermarketInterface {
   override def payForBeer[Items]: (Coin |*| Shopping[Beer |*| Items]) -⚬ (Beer |*| Shopping[Items]) =
     payForItem[Beer, Items]
 
-  private implicit def signalingJunctionBorrowedBasket: SignalingJunction.Positive[BorrowedBasket] =
+  private given signalingJunctionBorrowedBasket: SignalingJunction.Positive[BorrowedBasket] =
     SignalingJunction.Positive.byFst
 
   private def returnBasket  : (Basket |*| -[Basket]) -⚬ One = backvert

--- a/examples/src/main/scala/libretto/examples/supermarket/baskets.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/baskets.scala
@@ -1,6 +1,7 @@
 package libretto.examples.supermarket
 
 import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.scalettoLib.given
 
 object baskets {
   opaque type Basket = Val[Int]
@@ -25,6 +26,6 @@ object baskets {
   def destroyBaskets: LList1[Basket] -⚬ Done =
     LList1.foldMap(destroyBasket)
 
-  implicit def signalingJunctionBasket: SignalingJunction.Positive[Basket] =
+  given SignalingJunction.Positive[Basket] =
     signalingJunctionPositiveVal
 }

--- a/examples/src/main/scala/libretto/examples/supermarket/baskets.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/baskets.scala
@@ -1,6 +1,6 @@
 package libretto.examples.supermarket
 
-import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.*
 import libretto.scaletto.StarterKit.scalettoLib.given
 
 object baskets {

--- a/examples/src/main/scala/libretto/examples/supermarket/goods.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/goods.scala
@@ -9,8 +9,8 @@ trait AbstractGoods {
   type ToiletPaper
   type Beer
 
-  implicit def signalingJunctionToiletPaper: SignalingJunction.Positive[ToiletPaper]
-  implicit def signalingJunctionBeer:        SignalingJunction.Positive[Beer]
+  given signalingJunctionToiletPaper: SignalingJunction.Positive[ToiletPaper]
+  given signalingJunctionBeer:        SignalingJunction.Positive[Beer]
 }
 
 trait GoodsProducer extends AbstractGoods {
@@ -27,10 +27,10 @@ object Goods extends GoodsProducer with GoodsConsumer {
   override opaque type ToiletPaper = Done
   override opaque type Beer        = Done
 
-  override implicit def signalingJunctionToiletPaper: SignalingJunction.Positive[ToiletPaper] =
+  override given signalingJunctionToiletPaper: SignalingJunction.Positive[ToiletPaper] =
     SignalingJunction.Positive.signalingJunctionPositiveDone
 
-  override implicit def signalingJunctionBeer: SignalingJunction.Positive[Beer] =
+  override given signalingJunctionBeer: SignalingJunction.Positive[Beer] =
     SignalingJunction.Positive.signalingJunctionPositiveDone
 
   override def produceToiletPaper: Done -⚬ ToiletPaper =

--- a/examples/src/main/scala/libretto/examples/supermarket/goods.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/goods.scala
@@ -1,6 +1,6 @@
 package libretto.examples.supermarket
 
-import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.*
 
 /** Our supermarket specializes in the most wanted items in a pandemic,
   * namely toilet paper and beer.

--- a/examples/src/main/scala/libretto/examples/supermarket/money.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/money.scala
@@ -1,38 +1,38 @@
 package libretto.examples.supermarket
 
 import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.scalettoLib.given
 
 object money {
   opaque type Coin = Done
   opaque type CoinBank = Val[Int] // number of coins
 
   def forgeCoin: Done -⚬ Coin =
-      id[Done]
+    id[Done]
 
   def sendCoin: (Coin |*| -[Coin]) -⚬ One =
-      backvert
+    backvert
 
   def receiveCoin: One -⚬ (-[Coin] |*| Coin) =
-      forevert
+    forevert
 
   def newCoinBank: Done -⚬ CoinBank =
-      constVal(0)
+    constVal(0)
 
   def openCoinBank: CoinBank -⚬ Val[Int] =
-      id
+    id
 
   def depositCoin: (Coin |*| CoinBank) -⚬ CoinBank =
-      awaitPosFst[CoinBank] > mapVal(_ + 1)
+    awaitPosFst[CoinBank] > mapVal(_ + 1)
 
-  implicit def signalingJunctionCoin: SignalingJunction.Positive[Coin] =
-      SignalingJunction.Positive. signalingJunctionPositiveDone
+  given SignalingJunction.Positive[Coin] =
+    SignalingJunction.Positive. signalingJunctionPositiveDone
 
-  implicit def junctionCoinBank: Junction.Positive[CoinBank] =
-      junctionVal
+  given Junction.Positive[CoinBank] =
+    junctionVal
 
-  implicit def semigroupCoinBank: Semigroup[CoinBank] =
-      new Semigroup[CoinBank] {
-      override def combine: (CoinBank |*| CoinBank) -⚬ CoinBank =
-          unliftPair > mapVal { case (a, b) => a + b }
-      }
+  given Semigroup[CoinBank] with {
+    override def combine: (CoinBank |*| CoinBank) -⚬ CoinBank =
+      unliftPair > mapVal { case (a, b) => a + b }
+  }
 }

--- a/examples/src/main/scala/libretto/examples/supermarket/money.scala
+++ b/examples/src/main/scala/libretto/examples/supermarket/money.scala
@@ -1,6 +1,6 @@
 package libretto.examples.supermarket
 
-import libretto.scaletto.StarterKit._
+import libretto.scaletto.StarterKit.*
 import libretto.scaletto.StarterKit.scalettoLib.given
 
 object money {

--- a/examples/src/main/scala/libretto/examples/tv/TvBroadcaster.scala
+++ b/examples/src/main/scala/libretto/examples/tv/TvBroadcaster.scala
@@ -1,8 +1,8 @@
 package libretto.examples.tv
 
-import libretto.scaletto.StarterKit._
-import libretto.scaletto.StarterKit.$._
-import libretto.stream.scaletto.DefaultStreams._
+import libretto.scaletto.StarterKit.*
+import libretto.scaletto.StarterKit.$.*
+import libretto.stream.scaletto.DefaultStreams.*
 import TvChannel.{Cooking, Discovery, Sport}
 import TvInterface.{Channels, Tv, TvStream}
 

--- a/examples/src/main/scala/libretto/examples/tv/TvChannel.scala
+++ b/examples/src/main/scala/libretto/examples/tv/TvChannel.scala
@@ -6,6 +6,6 @@ object TvChannel {
   case class Sport()
 }
 
-import TvChannel._
+import TvChannel.*
 
 type TvChannel = Discovery | Cooking | Sport

--- a/examples/src/main/scala/libretto/examples/tv/TvInterface.scala
+++ b/examples/src/main/scala/libretto/examples/tv/TvInterface.scala
@@ -1,7 +1,7 @@
 package libretto.examples.tv
 
-import libretto.scaletto.StarterKit._
-import libretto.stream.scaletto.DefaultStreams._
+import libretto.scaletto.StarterKit.*
+import libretto.stream.scaletto.DefaultStreams.*
 
 object TvInterface {
   type Tv = Rec[TvF]

--- a/examples/src/main/scala/libretto/examples/tv/TvViewer.scala
+++ b/examples/src/main/scala/libretto/examples/tv/TvViewer.scala
@@ -1,10 +1,10 @@
 package libretto.examples.tv
 
-import libretto.scaletto.StarterKit._
-import libretto.scaletto.StarterKit.$._
-import libretto.stream.scaletto.DefaultStreams._
+import libretto.scaletto.StarterKit.*
+import libretto.scaletto.StarterKit.$.*
+import libretto.stream.scaletto.DefaultStreams.*
 import TvChannel.{Cooking, Discovery, Sport}
-import TvInterface._
+import TvInterface.*
 import TvInterface.Tv.{turnOff, watch}
 
 object TvViewer {

--- a/examples/src/test/scala/libretto/examples/diningPhilosophers/DiningPhilosophersTests.scala
+++ b/examples/src/test/scala/libretto/examples/diningPhilosophers/DiningPhilosophersTests.scala
@@ -1,8 +1,8 @@
 package libretto.examples.diningPhilosophers
 
-import libretto.scaletto.StarterKit.dsl._
-import libretto.scaletto.StarterKit.dsl.$._
-import libretto.scaletto.StarterKit.coreLib._
+import libretto.scaletto.StarterKit.dsl.*
+import libretto.scaletto.StarterKit.dsl.$.*
+import libretto.scaletto.StarterKit.coreLib.*
 import libretto.testing.scaletto.StarterTestKit
 import libretto.testing.scalatest.scaletto.ScalatestStarterTestSuite
 import libretto.testing.TestCase

--- a/examples/src/test/scala/libretto/examples/interactionNets/unaryArithmetic/UnaryArithmeticTests.scala
+++ b/examples/src/test/scala/libretto/examples/interactionNets/unaryArithmetic/UnaryArithmeticTests.scala
@@ -1,7 +1,7 @@
 package libretto.examples.interactionNets.unaryArithmetic
 
-import libretto.examples.interactionNets.unaryArithmetic._
-import libretto.scaletto.StarterKit._
+import libretto.examples.interactionNets.unaryArithmetic.*
+import libretto.scaletto.StarterKit.*
 import libretto.testing.scalatest.scaletto.ScalatestStarterTestSuite
 import libretto.testing.scaletto.StarterTestKit
 import libretto.testing.TestCase

--- a/lambda/src/main/scala/libretto/lambda/Bin.scala
+++ b/lambda/src/main/scala/libretto/lambda/Bin.scala
@@ -13,7 +13,7 @@ import libretto.lambda.util.TypeEq.Refl
  * @tparam A captures the complete structure of the tree
  */
 sealed trait Bin[<*>[_, _], T[_], F[_], A] {
-  import Bin._
+  import Bin.*
 
   def <*>[B](that: Bin[<*>, T, F, B]): Bin[<*>, T, F, A <*> B] =
     Branch(this, that)
@@ -254,7 +254,7 @@ sealed trait Bin[<*>[_, _], T[_], F[_], A] {
     leafTest: UniqueTypeArg[F],
     shuffle: Shuffle[<*>],
   ): FindRes[A, X, shuffle.~⚬] = {
-    import FindRes._
+    import FindRes.*
     import shuffle.~⚬
 
     this match {

--- a/lambda/src/main/scala/libretto/lambda/Focus.scala
+++ b/lambda/src/main/scala/libretto/lambda/Focus.scala
@@ -1,7 +1,7 @@
 package libretto.lambda
 
 sealed trait Focus[|*|[_, _], F[_]] {
-  import Focus._
+  import Focus.*
 
   def compose[G[_]](that: Focus[|*|, G]): Focus[|*|, [x] =>> F[G[x]]] =
     this match {

--- a/lambda/src/main/scala/libretto/lambda/Lambdas.scala
+++ b/lambda/src/main/scala/libretto/lambda/Lambdas.scala
@@ -256,7 +256,7 @@ object Lambdas {
     case class Undefined[VarLabel](vars: Var.Set[VarLabel]) extends Error[VarLabel]
 
     sealed trait LinearityViolation[VarLabel] extends Error[VarLabel] {
-      import LinearityViolation._
+      import LinearityViolation.*
 
       def combine(that: LinearityViolation[VarLabel]): LinearityViolation[VarLabel] =
         (this, that) match {
@@ -291,7 +291,7 @@ object Lambdas {
   }
 
   sealed trait Abstracted[Exp[_], |*|[_, _], AbsFun[_, _], V, A, B] {
-    import Abstracted._
+    import Abstracted.*
 
     def mapExpr[Exp2[_]](g: [X] => Exp[X] => Exp2[X]): Abstracted[Exp2, |*|, AbsFun, V, A, B] =
       this match {

--- a/lambda/src/main/scala/libretto/lambda/LambdasImpl.scala
+++ b/lambda/src/main/scala/libretto/lambda/LambdasImpl.scala
@@ -86,7 +86,7 @@ class LambdasImpl[-⚬[_, _], |*|[_, _], V](using
    * Non-linear: includes projections and multiple occurrences of the same variable.
    */
   sealed trait Expr[B] {
-    import Expr._
+    import Expr.*
 
     def resultVar: Var[B]
 
@@ -396,7 +396,7 @@ class LambdasImpl[-⚬[_, _], |*|[_, _], V](using
   }
 
   private case class HybridArrow[A, B](v: Var[A], tail: HybridArrow.Tail[Var[A], B]) {
-    import HybridArrow._
+    import HybridArrow.*
 
     def >[C](that: Tail[B, C]): HybridArrow[A, C] =
       HybridArrow(v, tail > that)
@@ -539,7 +539,7 @@ class LambdasImpl[-⚬[_, _], |*|[_, _], V](using
 
   private object HybridArrow {
     sealed trait Op[A, B] {
-      import Op._
+      import Op.*
 
       def project[C](p: Projection[|*|, B, C]): shOp.ProjectRes[A, C] =
         p match {

--- a/lambda/src/main/scala/libretto/lambda/Shuffle.scala
+++ b/lambda/src/main/scala/libretto/lambda/Shuffle.scala
@@ -298,7 +298,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
     def decompose1[X1, X2, Z](f: (X1 |*| X2) ~⚬ Z): Decomposition1[X1, X2, ?, ?, ?, ?, Z] =
       f match {
-        case Id()               => Decomposition1(Id(), Id(), TransferOpt.None(), implicitly)
+        case Id()               => Decomposition1(Id(), Id(), TransferOpt.None(), summon)
         case Bimap(Par(f1, f2)) => Decomposition1(f1, f2, TransferOpt.None(), implicitly)
         case Xfer(f1, f2, xfer) => Decomposition1(f1, f2, xfer, implicitly)
       }
@@ -927,7 +927,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
     def thenAssocLR[B11, B12, C2, C3](
       that: AssocLR[B11, B12, B2, C2, C3],
-    )(implicit
+    )(using
       ev: B1 =:= (B11 |*| B12),
     ): (A1 |*| A2) ~⚬ (B11 |*| (C2 |*| C3))
 
@@ -945,13 +945,13 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
     def thenXI[B21, B22, C2, C3](
       that: XI[B1, B21, B22, C2, C3],
-    )(implicit
+    )(using
       ev: B2 =:= (B21 |*| B22),
     ): (A1 |*| A2) ~⚬ (B21 |*| (C2 |*| C3))
 
     def thenIXI[B11, B12, B21, B22, C1, C2, C3, C4](
       that: IXI[B11, B12, B21, B22, C1, C2, C3, C4]
-    )(implicit
+    )(using
       ev1: B1 =:= (B11 |*| B12),
       ev2: B2 =:= (B21 |*| B22),
     ): (A1 |*| A2) ~⚬ ((C1 |*| C2) |*| (C3 |*| C4))
@@ -1028,7 +1028,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
     def >[C1, C2](that: Transfer[B1, B2, C1, C2]): (A1 |*| A2) ~⚬ (C1 |*| C2) =
       that after this
 
-    def to[C1, C2](implicit ev: (B1 |*| B2) =:= (C1 |*| C2)): Transfer[A1, A2, C1, C2] = {
+    def to[C1, C2](using ev: (B1 |*| B2) =:= (C1 |*| C2)): Transfer[A1, A2, C1, C2] = {
       val (ev1, ev2) = inj.unapply(ev)
       ev1.substituteCo[Transfer[A1, A2, _, C2]](ev2.substituteCo(this))
     }
@@ -1150,7 +1150,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenAssocLR[X21, X22, C2, C3](
         that: AssocLR[X21, X22, X1, C2, C3],
-      )(implicit
+      )(using
         ev: X2 =:= (X21 |*| X22),
       ): (X1 |*| X2) ~⚬ (X21 |*| (C2 |*| C3)) = {
         ev match { case TypeEq(Refl()) => xi[X1, X21, X22] > snd(swap > that.g.asShuffle) }
@@ -1174,7 +1174,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenXI[X11, X12, C2, C3](
         that: XI[X2, X11, X12, C2, C3],
-      )(implicit
+      )(using
         ev: X1 =:= (X11 |*| X12),
       ): (X1 |*| X2) ~⚬ (X11 |*| (C2 |*| C3)) =
         decompose(swap > that.g.asShuffle) match {
@@ -1183,7 +1183,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenIXI[B1, B2, B3, B4, C1, C2, C3, C4](
         that: IXI[B1, B2, B3, B4, C1, C2, C3, C4]
-      )(implicit
+      )(using
         ev1: X2 =:= (B1 |*| B2),
         ev2: X1 =:= (B3 |*| B4),
       ): (X1 |*| X2) ~⚬ ((C1 |*| C2) |*| (C3 |*| C4)) =
@@ -1391,7 +1391,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenAssocLR[A11, A12, C2, C3](
         that: AssocLR[A11, A12, B2 |*| B3, C2, C3],
-      )(implicit
+      )(using
         ev: A1 =:= (A11 |*| A12),
       ): ((A1 |*| A2) |*| A3) ~⚬ (A11 |*| (C2 |*| C3)) =
         ev match { case TypeEq(Refl()) =>
@@ -1425,7 +1425,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenXI[B21, B22, C2, C3](
         that: XI[A1, B21, B22, C2, C3],
-      )(implicit
+      )(using
         ev: (B2 |*| B3) =:= (B21 |*| B22),
       ): ((A1 |*| A2) |*| A3) ~⚬ (B21 |*| (C2 |*| C3)) =
         ev match {
@@ -1439,7 +1439,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenIXI[B11, B12, B21, B22, C1, C2, C3, C4](
         that: IXI[B11, B12, B21, B22, C1, C2, C3, C4]
-      )(implicit
+      )(using
         ev1: A1 =:= (B11 |*| B12),
         ev2: (B2 |*| B3) =:= (B21 |*| B22),
       ): ((A1 |*| A2) |*| A3) ~⚬ ((C1 |*| C2) |*| (C3 |*| C4)) =
@@ -1651,7 +1651,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenAssocLR[D1, D2, C2, C3](
         that: AssocLR[D1, D2, A3, C2, C3],
-      )(implicit
+      )(using
         ev: (B1 |*| B2) =:= (D1 |*| D2),
       ): (A1 |*| (A2 |*| A3)) ~⚬ (D1 |*| (C2 |*| C3)) =
         ev match {
@@ -1684,7 +1684,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenXI[A31, A32, C2, C3](
         that: XI[B1 |*| B2, A31, A32, C2, C3],
-      )(implicit
+      )(using
         ev: A3 =:= (A31 |*| A32),
       ): (A1 |*| (A2 |*| A3)) ~⚬ (A31 |*| (C2 |*| C3)) =
         decompose(assocRL > fst(g.asShuffle) > that.g.asShuffle) match {
@@ -1694,7 +1694,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenIXI[B11, B12, B21, B22, C1, C2, C3, C4](
         that: IXI[B11, B12, B21, B22, C1, C2, C3, C4]
-      )(implicit
+      )(using
         ev1: (B1 |*| B2) =:= (B11 |*| B12),
         ev2: A3 =:= (B21 |*| B22),
       ): (A1 |*| (A2 |*| A3)) ~⚬ ((C1 |*| C2) |*| (C3 |*| C4)) = {
@@ -1913,7 +1913,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenAssocLR[D1, D2, C2, C3](
         that: AssocLR[D1, D2, A2, C2, C3],
-      )(implicit
+      )(using
         ev: (B1 |*| B2) =:= (D1 |*| D2),
       ): ((A1 |*| A2) |*| A3) ~⚬ (D1 |*| (C2 |*| C3)) =
         TransferOpt.decompose(ev.biSubst(g)) match {
@@ -1947,7 +1947,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenXI[A21, A22, C2, C3](
         that: XI[(B1 |*| B2), A21, A22, C2, C3],
-      )(implicit
+      )(using
         ev: A2 =:= (A21 |*| A22),
       ): ((A1 |*| A2) |*| A3) ~⚬ (A21 |*| (C2 |*| C3)) =
         decompose(IX(g).asShuffle > that.g.asShuffle) match {
@@ -1956,7 +1956,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenIXI[B11, B12, B21, B22, C1, C2, C3, C4](
         that: IXI[B11, B12, B21, B22, C1, C2, C3, C4]
-      )(implicit
+      )(using
         ev1: (B1 |*| B2) =:= (B11 |*| B12),
         ev2: A2 =:= (B21 |*| B22),
       ): ((A1 |*| A2) |*| A3) ~⚬ ((C1 |*|C2) |*| (C3 |*| C4)) =
@@ -2189,7 +2189,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenAssocLR[A21, A22, C2, C3](
         that: AssocLR[A21, A22, B2 |*| B3, C2, C3],
-      )(implicit
+      )(using
         ev: A2 =:= (A21 |*| A22),
       ): (A1 |*| (A2 |*| A3)) ~⚬ (A21 |*| (C2 |*| C3)) =
         ev match { case TypeEq(Refl()) =>
@@ -2227,7 +2227,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenXI[B2_, B3_, C2, C3](
         that: XI[A2, B2_, B3_, C2, C3],
-      )(implicit
+      )(using
         ev: (B2 |*| B3) =:= (B2_ |*| B3_),
       ): (A1 |*| (A2 |*| A3)) ~⚬ (B2_ |*| (C2 |*| C3)) =
         ev match {
@@ -2241,7 +2241,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenIXI[B11, B12, B21, B22, C1, C2, C3, C4](
         that: IXI[B11, B12, B21, B22, C1, C2, C3, C4]
-      )(implicit
+      )(using
         ev1: A2 =:= (B11 |*| B12),
         ev2: (B2 |*| B3) =:= (B21 |*| B22),
       ): (A1 |*| (A2 |*| A3)) ~⚬ ((C1 |*| C2) |*| (C3 |*| C4)) = {
@@ -2489,7 +2489,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenAssocLR[D1, D2, C2, C3](
         that: AssocLR[D1, D2, B3 |*| B4, C2, C3],
-      )(implicit
+      )(using
         ev: (B1 |*| B2) =:= (D1 |*| D2),
       ): ((A1 |*| A2) |*| (A3 |*| A4)) ~⚬ (D1 |*| (C2 |*| C3)) = {
         val thiz = ev.biSubst[IXI[A1, A2, A3, A4, _, _, B3, B4]](this)
@@ -2535,7 +2535,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenXI[D1, D2, C2, C3](
         that: XI[(B1 |*| B2), D1, D2, C2, C3],
-      )(implicit
+      )(using
         ev: (B3 |*| B4) =:= (D1 |*| D2),
       ): ((A1 |*| A2) |*| (A3 |*| A4)) ~⚬ (D1 |*| (C2 |*| C3)) = {
         val thiz = ev.biSubst[IXI[A1, A2, A3, A4, B1, B2, _, _]](this)
@@ -2551,7 +2551,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
 
       override def thenIXI[B11, B12, B21, B22, C1, C2, C3, C4](
         that: IXI[B11, B12, B21, B22, C1, C2, C3, C4]
-      )(implicit
+      )(using
         ev1: (B1 |*| B2) =:= (B11 |*| B12),
         ev2: (B3 |*| B4) =:= (B21 |*| B22),
       ): ((A1 |*| A2) |*| (A3 |*| A4)) ~⚬ ((C1 |*| C2) |*| (C3 |*| C4)) =
@@ -2752,7 +2752,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
     def zip[C, D](that: C =:= D): (A |*| C) =:= (B |*| D) =
       that.substituteCo[[x] =>> (A |*| C) =:= (B |*| x)](
         ev.substituteCo[[x] =>> (A |*| C) =:= (x |*| C)](
-          implicitly[(A |*| C) =:= (A |*| C)]
+          summon[(A |*| C) =:= (A |*| C)]
         )
       )
   }

--- a/lambda/src/main/scala/libretto/lambda/Shuffle.scala
+++ b/lambda/src/main/scala/libretto/lambda/Shuffle.scala
@@ -2,13 +2,13 @@ package libretto.lambda
 
 import libretto.lambda.{Projection => P}
 import libretto.lambda.util.{BiInjective, Exists, TypeEq}
-import libretto.lambda.util.BiInjective._
+import libretto.lambda.util.BiInjective.*
 import libretto.lambda.util.TypeEq.Refl
 import libretto.lambda.Projection.Proper
 
 class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
   sealed trait ~⚬[A, B] {
-    import ~⚬._
+    import ~⚬.*
 
     def >[C](that: B ~⚬ C): A ~⚬ C =
       (this, that) match {
@@ -584,7 +584,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
       val p: Projection.Proper[|*|, A, X]
       val f: X ~⚬ C
 
-      import ProjectProperRes._
+      import ProjectProperRes.*
 
       def unproper: ProjectRes[A, C] =
         this match
@@ -606,7 +606,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
       }
     }
   }
-  import ~⚬._
+  import ~⚬.*
 
   /** Two parallel operations, at least one of which is not [[Id]]. */
   enum Par[X1, X2, Y1, Y2] {
@@ -917,7 +917,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
   }
 
   sealed trait Transfer[A1, A2, B1, B2] extends TransferOpt[A1, A2, B1, B2] {
-    import Transfer._
+    import Transfer.*
 
     def after[Z1, Z2](that: Transfer[Z1, Z2, A1, A2]): (Z1 |*| Z2) ~⚬ (B1 |*| B2)
 
@@ -1034,7 +1034,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
     }
 
     override def fold[->[_, _]](using ev: SymmetricSemigroupalCategory[->, |*|]): (A1 |*| A2) -> (B1 |*| B2) = {
-      import ev._
+      import ev.*
 
       extension [X, Y, Z](f: X -> Y) {
         def >(g: Y -> Z): X -> Z =

--- a/lambda/src/main/scala/libretto/lambda/Shuffled.scala
+++ b/lambda/src/main/scala/libretto/lambda/Shuffled.scala
@@ -364,7 +364,7 @@ sealed abstract class Shuffled[->[_, _], |*|[_, _]](using BiInjective[|*|]) {
   }
 
   sealed trait Plated[A, B] {
-    import Plated._
+    import Plated.*
 
     def afterPermeable[Z](that: Permeable[Z, A]): Plated.Preshuffled[Z, ?, B] =
       that match {
@@ -1039,7 +1039,7 @@ sealed abstract class Shuffled[->[_, _], |*|[_, _]](using BiInjective[|*|]) {
       ) extends UnconsSomeRes[F[X], B]
     }
   }
-  import Plated._
+  import Plated.*
 
   case class RevTransferOpt[A1, A2, B1, B2](t: TransferOpt[B1, B2, A1, A2]) {
     def fold(using ev: SymmetricSemigroupalCategory[->, |*|]): (A1 |*| A2) -> (B1 |*| B2) =

--- a/lambda/src/main/scala/libretto/lambda/Shuffled.scala
+++ b/lambda/src/main/scala/libretto/lambda/Shuffled.scala
@@ -1085,7 +1085,7 @@ sealed abstract class Shuffled[->[_, _], |*|[_, _]](using BiInjective[|*|]) {
   def id[X]: Shuffled[X, X] =
     Permeable.id
 
-  def id[X, Y](implicit ev: X =:= Y): Shuffled[X, Y] =
+  def id[X, Y](using ev: X =:= Y): Shuffled[X, Y] =
     ev.substituteCo(Permeable.id[X])
 
   def pure[X, Y](f: X ~⚬ Y): Shuffled[X, Y] =

--- a/lambda/src/main/scala/libretto/lambda/Sink.scala
+++ b/lambda/src/main/scala/libretto/lambda/Sink.scala
@@ -4,7 +4,7 @@ import libretto.lambda.util.{Applicative, Monad}
 
 /** A collection of arrows of the form `Ai --> B`, with `A = A1 <+> ... <+> An`. */
 sealed trait Sink[-->[_, _], <+>[_, _], A, B] {
-  import Sink._
+  import Sink.*
 
   def <+>[X](that: Sink[-->, <+>, X, B]): Sink[-->, <+>, A <+> X, B] =
     Join(this, that)

--- a/lambda/src/main/scala/libretto/lambda/util/BiInjective.scala
+++ b/lambda/src/main/scala/libretto/lambda/util/BiInjective.scala
@@ -9,7 +9,7 @@ object BiInjective {
     summon[BiInjective[F]]
 
   extension [F[_, _], A, B, X, Y](ev: F[A, B] =:= F[X, Y]) {
-    def biSubst[G[_, _]](g: G[A, B])(implicit inj: BiInjective[F]): G[X, Y] = {
+    def biSubst[G[_, _]](g: G[A, B])(using inj: BiInjective[F]): G[X, Y] = {
       val inj(ev1, ev2) = ev
       ev2.substituteCo[G[X, _]](ev1.substituteCo[G[_, B]](g))
     }

--- a/lambda/src/main/scala/libretto/lambda/util/SourcePos.scala
+++ b/lambda/src/main/scala/libretto/lambda/util/SourcePos.scala
@@ -5,10 +5,10 @@ import scala.quoted._
 final case class SourcePos(path: String, filename: String, line: Int)
 
 object SourcePos {
-  def apply(implicit pos: SourcePos): SourcePos =
+  def apply(using pos: SourcePos): SourcePos =
     pos
 
-  inline implicit def sourcePosition: SourcePos =
+  inline given SourcePos =
     ${ sourcePositionImpl }
 
   def sourcePositionImpl(using Quotes): Expr[SourcePos] = {

--- a/lambda/src/main/scala/libretto/lambda/util/SourcePos.scala
+++ b/lambda/src/main/scala/libretto/lambda/util/SourcePos.scala
@@ -1,6 +1,6 @@
 package libretto.lambda.util
 
-import scala.quoted._
+import scala.quoted.*
 
 final case class SourcePos(path: String, filename: String, line: Int)
 

--- a/lambda/src/test/scala/libretto/lambda/LambdaTests.scala
+++ b/lambda/src/test/scala/libretto/lambda/LambdaTests.scala
@@ -1,6 +1,6 @@
 package libretto.lambda
 
-import libretto.lambda.Fun._
+import libretto.lambda.Fun.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class LambdaTests extends AnyFunSuite {

--- a/libretto-zio/src/main/scala/libretto/zio_interop/Ztuff.scala
+++ b/libretto-zio/src/main/scala/libretto/zio_interop/Ztuff.scala
@@ -8,7 +8,7 @@ import zio.stream.UStream
 
 /** ZIO stuff that can be mapped to Libretto type `A`. */
 sealed trait Ztuff[A] {
-  import Ztuff._
+  import Ztuff.*
 
   def |*|[B](that: Ztuff[B]): Ztuff[A |*| B] =
     Ztuff.Pair(this, that)

--- a/mashup-examples/src/main/scala/libretto/mashup/examples/weather/WeatherService.scala
+++ b/mashup-examples/src/main/scala/libretto/mashup/examples/weather/WeatherService.scala
@@ -4,7 +4,7 @@ import libretto.lambda.util.SourcePos
 import libretto.mashup.{Input, Output, Runtime, Service}
 import libretto.mashup.dsl.{-->, ###, EmptyResource, Expr, Float64, Fun, LambdaContext, Record, Text, alsoElim, closure, fun, of}
 import libretto.mashup.rest.{Endpoint, RestApi}
-import libretto.mashup.rest.RelativeUrl._
+import libretto.mashup.rest.RelativeUrl.*
 import zio.{Scope, ZIO}
 
 object WeatherService {

--- a/mashup/src/main/scala/libretto/mashup/BodyType.scala
+++ b/mashup/src/main/scala/libretto/mashup/BodyType.scala
@@ -32,7 +32,7 @@ object BodyType {
   }
 
   object Json {
-    import JsonType._
+    import JsonType.*
 
     private def extractJson[A](using rt: Runtime, exn: rt.Execution)(
       typ: JsonType[A],

--- a/mashup/src/main/scala/libretto/mashup/ConstValue.scala
+++ b/mashup/src/main/scala/libretto/mashup/ConstValue.scala
@@ -3,6 +3,6 @@ package libretto.mashup
 final case class ConstValue[T](value: T)
 
 object ConstValue {
-  inline implicit def constValue[T]: ConstValue[T] =
+  inline given [T]: ConstValue[T] =
     ConstValue(scala.compiletime.constValue[T])
 }

--- a/mashup/src/main/scala/libretto/mashup/JsonType.scala
+++ b/mashup/src/main/scala/libretto/mashup/JsonType.scala
@@ -1,6 +1,6 @@
 package libretto.mashup
 
-import libretto.mashup.dsl._
+import libretto.mashup.dsl.*
 import zio.Chunk
 import zio.json.ast.Json
 

--- a/mashup/src/main/scala/libretto/mashup/MashupDsl.scala
+++ b/mashup/src/main/scala/libretto/mashup/MashupDsl.scala
@@ -287,13 +287,12 @@ trait MashupDsl {
   }
 
   object Comonoid {
-    implicit val comonoidEmpty: Comonoid[EmptyResource] =
-      new Comonoid[EmptyResource] {
-        override def counit: Fun[EmptyResource, EmptyResource] =
-          id[EmptyResource]
+    given Comonoid[EmptyResource] with {
+      override def counit: Fun[EmptyResource, EmptyResource] =
+        id[EmptyResource]
 
-        override def split: Fun[EmptyResource, EmptyResource ** EmptyResource] =
-          fun(_ => Expr.unit ** Expr.unit)
-      }
+      override def split: Fun[EmptyResource, EmptyResource ** EmptyResource] =
+        fun(_ => Expr.unit ** Expr.unit)
+    }
   }
 }

--- a/mashup/src/main/scala/libretto/mashup/MashupKitImpl.scala
+++ b/mashup/src/main/scala/libretto/mashup/MashupKitImpl.scala
@@ -308,7 +308,7 @@ object MashupKitImpl extends MashupKit { kit =>
         override type ScalaRepr = (A.ScalaRepr, (N, T.ScalaRepr))
 
         override def junction: Junction.Positive[Record[A ### (N of T)]] =
-          Junction.Positive.both(A.junction, T.junction)
+          Junction.Positive.both(using A.junction, T.junction)
 
         override def toScalaValue: Fun[Record[A ### (N of T)], Val[ScalaRepr]] =
           par(A.toScalaValue, T.toScalaValue) > unliftPair > mapVal { case (a, t) => (a, (N.value, t)) }

--- a/mashup/src/main/scala/libretto/mashup/ZioHttpServer.scala
+++ b/mashup/src/main/scala/libretto/mashup/ZioHttpServer.scala
@@ -1,7 +1,7 @@
 package libretto.mashup
 
 import java.net.InetSocketAddress
-import zio.http._
+import zio.http.*
 import zio.http.Server
 import zio.{Fiber, Promise, Queue, Scope, UIO, ZIO}
 

--- a/mashup/src/main/scala/libretto/mashup/rest/Path.scala
+++ b/mashup/src/main/scala/libretto/mashup/rest/Path.scala
@@ -1,6 +1,6 @@
 package libretto.mashup.rest
 
-import Path._
+import Path.*
 
 enum Path {
   case Empty

--- a/mashup/src/main/scala/libretto/mashup/rest/PathTemplate.scala
+++ b/mashup/src/main/scala/libretto/mashup/rest/PathTemplate.scala
@@ -1,7 +1,7 @@
 package libretto.mashup.rest
 
 import libretto.mashup.{MappedValue, Runtime}
-import libretto.mashup.dsl._
+import libretto.mashup.dsl.*
 import libretto.util.Async
 import scala.util.{Failure, Success, Try}
 

--- a/mashup/src/main/scala/libretto/mashup/rest/RelativeUrl.scala
+++ b/mashup/src/main/scala/libretto/mashup/rest/RelativeUrl.scala
@@ -1,8 +1,8 @@
 package libretto.mashup.rest
 
 import libretto.mashup.{MappedValue, Runtime}
-import libretto.mashup.dsl._
-import libretto.mashup.rest.RelativeUrl._
+import libretto.mashup.dsl.*
+import libretto.mashup.rest.RelativeUrl.*
 import libretto.util.Async
 import scala.util.Try
 

--- a/stream/src/main/scala/libretto/stream/CoreStreams.scala
+++ b/stream/src/main/scala/libretto/stream/CoreStreams.scala
@@ -18,7 +18,7 @@ class CoreStreams[DSL <: CoreDSL, Lib <: CoreLib[DSL]](
 ) {
   import dsl._
   import dsl.$._
-  import lib._
+  import lib.{_, given}
 
   type StreamLeaderF[S, T, A, X]   = S |+| (T |&| (A |*| X))
   type StreamFollowerF[S, T, A, X] = S |&| (T |+| (A |*| X))
@@ -428,7 +428,7 @@ class CoreStreams[DSL <: CoreDSL, Lib <: CoreLib[DSL]](
     }
 
     /** Delays the first action ([[poll]] or [[close]]) until the [[Done]] signal completes. */
-    def delayBy[A](implicit ev: Junction.Positive[A]): (Done |*| Source[A]) -⚬ Source[A] =
+    def delayBy[A](using ev: Junction.Positive[A]): (Done |*| Source[A]) -⚬ Source[A] =
       id                                           [  Done |*|      Source[A]                  ]
         .>.snd(toChoice)                        .to[  Done |*| (Done  |&|           Polled[A]) ]
         .>(delayChoiceUntilDone)                .to[ (Done |*|  Done) |&| (Done |*| Polled[A]) ]
@@ -820,13 +820,14 @@ class CoreStreams[DSL <: CoreDSL, Lib <: CoreLib[DSL]](
       SourceT.from(onClose, onPoll)
     }
 
-    implicit def positiveJunction[A](implicit A: Junction.Positive[A]): Junction.Positive[Source[A]] =
+    given positiveJunction[A : Junction.Positive]: Junction.Positive[Source[A]] =
       Junction.Positive.from(Source.delayBy)
 
-    implicit def negativeSignaling[A]: Signaling.Negative[Source[A]] =
+    given negativeSignaling[A]: Signaling.Negative[Source[A]] =
       Signaling.Negative.from(Source.notifyAction[A])
 
-    implicit def negativeSource[A](implicit A: Junction.Positive[A]): SignalingJunction.Negative[Source[A]] =
+    // negativeSource
+    given [A : Junction.Positive]: SignalingJunction.Negative[Source[A]] =
       SignalingJunction.Negative.from(
         negativeSignaling,
         Junction.invert(positiveJunction),
@@ -900,10 +901,10 @@ class CoreStreams[DSL <: CoreDSL, Lib <: CoreLib[DSL]](
           .either(upstreamClosed, upstreamValue)
       }
 
-      implicit def positivePolled[A](implicit A: Junction.Positive[A]): SignalingJunction.Positive[Polled[A]] =
-        SignalingJunction.Positive.eitherPos(
+      given [A : Junction.Positive]: SignalingJunction.Positive[Polled[A]] =
+        SignalingJunction.Positive.eitherPos(using
           SignalingJunction.Positive.signalingJunctionPositiveDone,
-          Junction.Positive.byFst(A),
+          Junction.Positive.byFst,
         )
     }
   }

--- a/stream/src/main/scala/libretto/stream/CoreStreams.scala
+++ b/stream/src/main/scala/libretto/stream/CoreStreams.scala
@@ -16,9 +16,9 @@ class CoreStreams[DSL <: CoreDSL, Lib <: CoreLib[DSL]](
   val dsl: DSL,
   val lib: Lib with CoreLib[dsl.type],
 ) {
-  import dsl._
-  import dsl.$._
-  import lib.{_, given}
+  import dsl.*
+  import dsl.$.*
+  import lib.{*, given}
 
   type StreamLeaderF[S, T, A, X]   = S |+| (T |&| (A |*| X))
   type StreamFollowerF[S, T, A, X] = S |&| (T |+| (A |*| X))

--- a/stream/src/main/scala/libretto/stream/InvertStreams.scala
+++ b/stream/src/main/scala/libretto/stream/InvertStreams.scala
@@ -16,9 +16,9 @@ class InvertStreams[DSL <: InvertDSL, Lib <: CoreLib[DSL]](
   override val dsl: DSL,
   override val lib: Lib with CoreLib[dsl.type],
 ) extends CoreStreams[DSL, Lib](dsl, lib) {
-  import dsl._
-  import dsl.$._
-  import lib._
+  import dsl.*
+  import dsl.$.*
+  import lib.*
 
   opaque type Drain[A] = StreamT[Need, -[A]]
   opaque type Sink[A]  = SourceT[Need, -[A]]

--- a/stream/src/main/scala/libretto/stream/scaletto/BinarySearchTree.scala
+++ b/stream/src/main/scala/libretto/stream/scaletto/BinarySearchTree.scala
@@ -19,11 +19,11 @@ class BinarySearchTree[DSL <: Scaletto, CLib <: CoreLib[DSL], SLib <: ScalettoLi
   val coreLib: CLib with CoreLib[dsl.type],
   val scalettoLib: SLib with ScalettoLib[dsl.type, coreLib.type],
 ) {
-  import dsl._
-  import coreLib._
-  import coreLib.Bool._
-  import coreLib.Compared._
-  import scalettoLib.{_, given}
+  import dsl.*
+  import coreLib.*
+  import coreLib.Bool.*
+  import coreLib.Compared.*
+  import scalettoLib.{*, given}
 
   private def fstLens[A, B]: Lens[A |*| B, A] =
     Transportive.fst[B].lens[A]

--- a/stream/src/main/scala/libretto/stream/scaletto/ScalettoStreams.scala
+++ b/stream/src/main/scala/libretto/stream/scaletto/ScalettoStreams.scala
@@ -56,15 +56,15 @@ abstract class ScalettoStreams {
 
   private lazy val Tree = BinarySearchTree(dsl, coreLib, scalettoLib)
 
-  import dsl._
-  import dsl.$._
-  import coreLib._
-  import scalettoLib.{_, given}
-  import underlying._
-  import Tree._
+  import dsl.*
+  import dsl.$.*
+  import coreLib.*
+  import scalettoLib.{*, given}
+  import underlying.*
+  import Tree.*
   import Comonoid.given
 
-  export underlying.{lib => _, dsl => _, _}
+  export underlying.{lib => _, dsl => _, *}
 
   type ValSourceT[T, A] = SourceT[T, Val[A]]
 

--- a/stream/src/main/scala/libretto/stream/scaletto/ScalettoStreams.scala
+++ b/stream/src/main/scala/libretto/stream/scaletto/ScalettoStreams.scala
@@ -528,8 +528,6 @@ abstract class ScalettoStreams {
         }
 
       val go: ((Polled[A] |*| Source.Polled[KSubs]) |*| DT[K, V]) -⚬ Done = rec { self =>
-        import Source.Polled.positivePolled
-
         given SignalingJunction.Positive[KSubs] =
           SignalingJunction.Positive.byFst[Val[K], -[ValSource[V]]]
 
@@ -577,9 +575,6 @@ abstract class ScalettoStreams {
 
       def delayBy[A]: (Done |*| Polled[A]) -⚬ Polled[A] =
         Source.Polled.delayBy
-
-      implicit def positivePolled[A]: SignalingJunction.Positive[Polled[A]] =
-        Source.Polled.positivePolled[Val[A]]
 
       def dup[A](
         dupSource: ValSource[A] -⚬ (ValSource[A] |*| ValSource[A]),

--- a/stream/src/test/scala/libretto/stream/StreamsTests.scala
+++ b/stream/src/test/scala/libretto/stream/StreamsTests.scala
@@ -1,14 +1,14 @@
 package libretto.stream
 
 import libretto.CoreLib
-import libretto.lambda.util.Monad.syntax._
+import libretto.lambda.util.Monad.syntax.*
 import libretto.scaletto.ScalettoLib
 import libretto.stream.CoreStreams
 import libretto.stream.scaletto.ScalettoStreams
 import libretto.testing.TestCase
 import libretto.testing.scaletto.ScalettoTestKit
 import libretto.testing.scalatest.scaletto.ScalatestScalettoTestSuite
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class StreamsTests extends ScalatestScalettoTestSuite {
   override def testCases(using kit: ScalettoTestKit): List[(String, TestCase[kit.type])] = {
@@ -20,11 +20,11 @@ class StreamsTests extends ScalatestScalettoTestSuite {
     val invertStreams = InvertStreams(dsl, coreLib)
     val scalettoStreams = ScalettoStreams(kit.dsl, coreLib, scalettoLib, invertStreams)
 
-    import dsl._
-    import dsl.$._
-    import coreLib._
-    import scalettoLib.{given, _}
-    import scalettoStreams._
+    import dsl.*
+    import dsl.$.*
+    import coreLib.*
+    import scalettoLib.{*, given}
+    import scalettoStreams.*
 
     List(
       "toList ⚬ fromList = id" -> TestCase

--- a/testing/src/main/scala/libretto/testing/TestCase.scala
+++ b/testing/src/main/scala/libretto/testing/TestCase.scala
@@ -2,7 +2,7 @@ package libretto.testing
 
 import libretto.lambda.util.SourcePos
 import libretto.testing.TestKit.dsl
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 sealed trait TestCase[TK <: TestKit] {
   def pending: TestCase[TK] =
@@ -20,7 +20,7 @@ object TestCase {
   sealed trait SingleProgram[TK <: TestKit] extends Single[TK] {
     val testKit: TK
     import testKit.{ExecutionParam, Outcome}
-    import testKit.dsl._
+    import testKit.dsl.*
     import testKit.bridge.Execution
 
     type O

--- a/testing/src/main/scala/libretto/testing/TestExecutor.scala
+++ b/testing/src/main/scala/libretto/testing/TestExecutor.scala
@@ -3,7 +3,7 @@ package libretto.testing
 import libretto.{CoreDSL, Executor}
 import libretto.Executor.CancellationReason
 import libretto.lambda.util.Monad
-import libretto.lambda.util.Monad.syntax._
+import libretto.lambda.util.Monad.syntax.*
 import libretto.util.Async
 import scala.concurrent.duration.FiniteDuration
 
@@ -11,7 +11,7 @@ trait TestExecutor[+TK <: TestKit] { self =>
   val testKit: TK
 
   import testKit.{ExecutionParam, Outcome}
-  import testKit.dsl._
+  import testKit.dsl.*
   import testKit.bridge.Execution
 
   def name: String
@@ -111,7 +111,7 @@ object TestExecutor {
   class UsingExecutor[E <: Executor](val executor: E) {
     import executor.ExecutionParam
     import executor.bridge.Execution
-    import executor.dsl._
+    import executor.dsl.*
 
     def runTestCase[O, P, X](
       body: Done -⚬ O,

--- a/testing/src/main/scala/libretto/testing/TestKit.scala
+++ b/testing/src/main/scala/libretto/testing/TestKit.scala
@@ -2,7 +2,7 @@ package libretto.testing
 
 import libretto.{CoreBridge, CoreDSL, ExecutionParams, Monad}
 import libretto.lambda.util.{Monad => ScalaMonad, SourcePos}
-import libretto.lambda.util.Monad.syntax._
+import libretto.lambda.util.Monad.syntax.*
 import libretto.util.Async
 import scala.annotation.targetName
 

--- a/testing/src/main/scala/libretto/testing/scaletto/ScalettoTestExecutor.scala
+++ b/testing/src/main/scala/libretto/testing/scaletto/ScalettoTestExecutor.scala
@@ -19,7 +19,7 @@ object ScalettoTestExecutor {
 
       override val dsl: bridge0.dsl.type = bridge0.dsl
       override val bridge: bridge0.type = bridge0
-      import dsl._
+      import dsl.*
       import bridge.Execution
 
       override type Assertion[A] = Val[String] |+| A
@@ -29,7 +29,7 @@ object ScalettoTestExecutor {
         ScalettoTestExecutor.ExecutionParam.manualClockParamsInstance
 
       private val coreLib = CoreLib(this.dsl)
-      import coreLib.{Monad => _, _}
+      import coreLib.{Monad => _, *}
 
       override def success[A]: A -⚬ Assertion[A] =
         injectR
@@ -137,7 +137,7 @@ object ScalettoTestExecutor {
       override val testKit: kit.type = kit
 
       import testKit.{ExecutionParam, Outcome}
-      import testKit.dsl._
+      import testKit.dsl.*
       import testKit.bridge.Execution
 
       override def execpAndCheck[O, P, Y](

--- a/testing/src/main/scala/libretto/testing/scaletto/ScalettoTestKit.scala
+++ b/testing/src/main/scala/libretto/testing/scaletto/ScalettoTestKit.scala
@@ -1,7 +1,7 @@
 package libretto.testing.scaletto
 
 import libretto.CoreLib
-import libretto.lambda.util.Monad.syntax._
+import libretto.lambda.util.Monad.syntax.*
 import libretto.scaletto.{Scaletto, ScalettoBridge}
 import libretto.testing.TestKit.dsl
 import libretto.testing.{TestKitOps, TestKitWithManualClock, TestResult}
@@ -11,11 +11,11 @@ trait ScalettoTestKit extends TestKitWithManualClock {
 
   override val bridge: ScalettoBridge.Of[dsl.type]
 
-  import dsl._
+  import dsl.*
   import bridge.Execution
 
   private lazy val coreLib = CoreLib(dsl)
-  import coreLib._
+  import coreLib.*
 
   def failure[A](msg: String): Done -⚬ Assertion[A]
 

--- a/tutorial/basics.md
+++ b/tutorial/basics.md
@@ -35,8 +35,8 @@ Libretto.
 The code snippets below use these imports:
 
 ```scala mdoc
-import libretto.scaletto.StarterKit.dsl._
-import libretto.scaletto.StarterKit.dsl.$._
+import libretto.scaletto.StarterKit.dsl.*
+import libretto.scaletto.StarterKit.dsl.$.*
 ```
 
 ```scala mdoc:invisible
@@ -48,7 +48,7 @@ object Types {
   type D
   type E
 }
-import Types._
+import Types.*
 ```
 
 ## Building blocks
@@ -1079,7 +1079,7 @@ If this is the main program
 
 ```scala mdoc
 object MyApp {
-  import scala.concurrent.duration._
+  import scala.concurrent.duration.*
 
   val prg: Done -⚬ Done =
     λ { start =>


### PR DESCRIPTION
Almost all `implicit`s are gone:

![Screenshot_20230629_184658](https://github.com/TomasMikula/libretto/assets/7350866/200a3bf6-50e0-4241-a1a6-db87a19793c6)

The rest needs special care. I'll open issues.

The PR is divided in two commits for review:
* The 1st part (older commit) is imho all changes that don't need any further discussion.
* I'll annotate the 2nd part with some thoughts: Not sure whether some parts should be further improved before merging.

The commits only compile when applied together. So this is a WIP PR.

After review / discussion I'll rewrite it to one big single commit (with a better commit message).