### PR TITLE
Last step in `import` rewrite to Scala 3 style

### DIFF
--- a/core-tests/src/test/scala/libretto/BasicTests.scala
+++ b/core-tests/src/test/scala/libretto/BasicTests.scala
@@ -38,7 +38,7 @@ class BasicTests extends ScalatestSuite[ScalettoTestKit] {
     )
 
   override def testCases(using kit: ScalettoTestKit): List[(String, TestCase[kit.type])] = {
-    import kit.{OutPort => _, *}
+    import kit.{OutPort as _, *}
     import dsl.*
     import dsl.$.*
     val coreLib = CoreLib(dsl)

--- a/core/src/main/scala/libretto/scaletto/StarterKit.scala
+++ b/core/src/main/scala/libretto/scaletto/StarterKit.scala
@@ -1,6 +1,6 @@
 package libretto.scaletto
 
-import java.util.concurrent.{Executor => JExecutor, Executors, ScheduledExecutorService}
+import java.util.concurrent.{Executor as JExecutor, Executors, ScheduledExecutorService}
 import libretto.{CoreLib, ClosedLib, InvertLib}
 import libretto.scaletto.impl.FreeScaletto
 import libretto.scaletto.impl.futurebased.{BridgeImpl, FutureExecutor}

--- a/core/src/main/scala/libretto/scaletto/impl/futurebased/FutureExecutor.scala
+++ b/core/src/main/scala/libretto/scaletto/impl/futurebased/FutureExecutor.scala
@@ -1,6 +1,6 @@
 package libretto.scaletto.impl.futurebased
 
-import java.util.concurrent.{Executor => JExecutor, Executors, ExecutorService, ScheduledExecutorService}
+import java.util.concurrent.{Executor as JExecutor, Executors, ExecutorService, ScheduledExecutorService}
 import libretto.{Executing, ExecutionParams, Scheduler}
 import libretto.Executor.CancellationReason
 import libretto.lambda.util.SourcePos

--- a/examples/src/main/scala/libretto/examples/diningPhilosophers/DiningPhilosophers.scala
+++ b/examples/src/main/scala/libretto/examples/diningPhilosophers/DiningPhilosophers.scala
@@ -6,7 +6,7 @@ object DiningPhilosophers extends StarterApp {
   import $.*
 
   val philosophers = Philosophers(ForksProvider)
-  import philosophers.{behavior => philosopher}
+  import philosophers.{behavior as philosopher}
   import ForksProvider.mkSharedFork
 
   override def blueprint: Done -⚬ Done =

--- a/examples/src/main/scala/libretto/examples/santa/solution1/SantaClaus.scala
+++ b/examples/src/main/scala/libretto/examples/santa/solution1/SantaClaus.scala
@@ -5,7 +5,7 @@ import libretto.scaletto.StarterKit.{*, given}
 import libretto.scaletto.StarterKit.Endless.{groupMap, mapSequentially, mergeEitherPreferred, take}
 import libretto.scaletto.StarterKit.LList1.{closeAll, eachNotifyBy, foldMap, map, sortBySignal, transform, unzipBy}
 import libretto.scaletto.StarterKit.Monoid.given
-import scala.{:: => NonEmptyList}
+import scala.{:: as NonEmptyList}
 
 object SantaClaus extends StarterApp {
   opaque type Reindeer = Val[String]
@@ -61,8 +61,8 @@ object SantaClaus extends StarterApp {
     def meetInStudy = act
   }
 
-  import RGroup.{Type => RGroup, deliverToys}
-  import EGroup.{Type => EGroup, meetInStudy}
+  import RGroup.{Type as RGroup, deliverToys}
+  import EGroup.{Type as EGroup, meetInStudy}
 
   def santa(nCycles: Int): Endless[RGroup |+| EGroup] -⚬ Done = {
     def go: (RGroup |+| EGroup) -⚬ Done =

--- a/examples/src/main/scala/libretto/examples/santa/solution2/SantaClaus.scala
+++ b/examples/src/main/scala/libretto/examples/santa/solution2/SantaClaus.scala
@@ -3,7 +3,7 @@ package libretto.examples.santa.solution2
 import libretto.scaletto.StarterApp
 import libretto.scaletto.StarterKit.*
 import libretto.stream.scaletto.DefaultStreams.Source
-import scala.{:: => NonEmptyList}
+import scala.{:: as NonEmptyList}
 
 object SantaClaus extends StarterApp {
   opaque type Reindeer = Val[String]

--- a/lambda/src/main/scala/libretto/lambda/Bin.scala
+++ b/lambda/src/main/scala/libretto/lambda/Bin.scala
@@ -66,8 +66,8 @@ sealed trait Bin[<*>[_, _], T[_], F[_], A] {
           case Right(a) => Partitioned.Right(Leaf(a))
       case Branch(l, r) =>
         import Partitioned.{Both, Left, Right}
-        import l.Partitioned.{Both => LBoth, Left => LLeft, Right => LRight}
-        import r.Partitioned.{Both => RBoth, Left => RLeft, Right => RRight}
+        import l.Partitioned.{Both as LBoth, Left as LLeft, Right as LRight}
+        import r.Partitioned.{Both as RBoth, Left as RLeft, Right as RRight}
 
         (l.partition(f), r.partition(f)) match
           case (LLeft(lg),        RLeft(rg))        => Left(lg <*> rg)

--- a/lambda/src/main/scala/libretto/lambda/LambdasImpl.scala
+++ b/lambda/src/main/scala/libretto/lambda/LambdasImpl.scala
@@ -1,6 +1,6 @@
 package libretto.lambda
 
-import libretto.{lambda => ll}
+import libretto.{lambda as ll}
 import libretto.lambda.Lambdas.Error
 import libretto.lambda.Lambdas.Error.LinearityViolation
 import libretto.lambda.util.{Applicative, BiInjective, Exists, Injective, Masked, TypeEq, UniqueTypeArg}
@@ -15,7 +15,7 @@ class LambdasImpl[-⚬[_, _], |*|[_, _], V](using
   given shuffle: Shuffle[|*|] = Shuffle[|*|]
   given shuffled: Shuffled.With[-⚬, |*|, shuffle.type] = Shuffled[-⚬, |*|](shuffle)
   import shuffled.shuffle.{~⚬, Transfer, TransferOpt}
-  import shuffled.{Shuffled => ≈⚬, assocLR, assocRL, fst, id, ix, ixi, lift, par, pure, snd, swap, xi}
+  import shuffled.{Shuffled as ≈⚬, assocLR, assocRL, fst, id, ix, ixi, lift, par, pure, snd, swap, xi}
 
   override type AbstractFun[A, B] =
     A ≈⚬ B
@@ -328,7 +328,7 @@ class LambdasImpl[-⚬[_, _], |*|[_, _], V](using
   ): EliminatedFromForest[A, B] = {
     import Lambdas.Abstracted.{Closure, Exact, Failure}
     import EliminatedFromForest.{FoundEach, FoundSome, NotFound}
-    import libretto.lambda.{CapturingFun => cf}
+    import libretto.lambda.{CapturingFun as cf}
 
     exprs.asBin match {
       case Bin.Leaf(b) =>
@@ -942,7 +942,7 @@ class LambdasImpl[-⚬[_, _], |*|[_, _], V](using
         C: Focus[|*|, C],
         D: Focus[|*|, D],
       ): Option[Tail[C[Var[X]], Y |*| Z]] = {
-        import shOp.shuffle.{zip => zipEq}
+        import shOp.shuffle.{zip as zipEq}
 
         (C, D) match {
           case (Focus.Id(), Focus.Id()) =>
@@ -984,7 +984,7 @@ class LambdasImpl[-⚬[_, _], |*|[_, _], V](using
     }
 
     val shOp = Shuffled[Op, |*|](shuffled.shuffle)
-    import shOp.shuffle.{zip => zipEq}
+    import shOp.shuffle.{zip as zipEq}
 
     type VarOp[A, B] = (Vars[A], Op[A, B])
     given shVOp: Shuffled.With[VarOp, |*|, shuffled.shuffle.type] =

--- a/lambda/src/main/scala/libretto/lambda/Shuffle.scala
+++ b/lambda/src/main/scala/libretto/lambda/Shuffle.scala
@@ -1,6 +1,6 @@
 package libretto.lambda
 
-import libretto.lambda.{Projection => P}
+import libretto.lambda.{Projection as P}
 import libretto.lambda.util.{BiInjective, Exists, TypeEq}
 import libretto.lambda.util.BiInjective.*
 import libretto.lambda.util.TypeEq.Refl
@@ -622,7 +622,7 @@ class Shuffle[|*|[_, _]](using inj: BiInjective[|*|]) {
       }
 
     def projectProper[C](p: Projection.Proper[|*|, Y1 |*| Y2, C]): ProjectProperRes[X1 |*| X2, C] = {
-      import libretto.lambda.{Projection => P}
+      import libretto.lambda.{Projection as P}
       val Par(f1, f2) = this
       p.fromPair[Y1, Y2].switch[ProjectProperRes[X1 |*| X2, C]](
         caseDiscardFst = { p2 =>

--- a/lambda/src/main/scala/libretto/lambda/Shuffled.scala
+++ b/lambda/src/main/scala/libretto/lambda/Shuffled.scala
@@ -1,6 +1,6 @@
 package libretto.lambda
 
-import libretto.lambda.{Projection => P}
+import libretto.lambda.{Projection as P}
 import libretto.lambda.util.{Applicative, BiInjective, Exists, TypeEq}
 import libretto.lambda.util.TypeEq.Refl
 import libretto.lambda.Projection.Proper
@@ -26,7 +26,7 @@ object Shuffled {
 
 sealed abstract class Shuffled[->[_, _], |*|[_, _]](using BiInjective[|*|]) {
   val shuffle: Shuffle[|*|]
-  import shuffle.{~⚬, Transfer, TransferOpt, zip => zipEq}
+  import shuffle.{~⚬, Transfer, TransferOpt, zip as zipEq}
 
   def biInjectiveProduct: BiInjective[|*|] = summon
 

--- a/lambda/src/main/scala/libretto/lambda/Var.scala
+++ b/lambda/src/main/scala/libretto/lambda/Var.scala
@@ -2,7 +2,7 @@ package libretto.lambda
 
 import libretto.lambda.util.{Injective, TypeEq, UniqueTypeArg}
 import libretto.lambda.util.TypeEq.Refl
-import scala.collection.{immutable => sci}
+import scala.collection.{immutable as sci}
 
 /**
  * @param P representation of variable's origin (e.g. source code position)

--- a/libretto-zio/src/main/scala/libretto/zio_interop/OutPort.scala
+++ b/libretto-zio/src/main/scala/libretto/zio_interop/OutPort.scala
@@ -11,7 +11,7 @@ class OutPort[A](
   val execution: bridge.Execution,
   val port: execution.OutPort[A],
 ) {
-  import execution.{OutPort => Port}
+  import execution.{OutPort as Port}
 
   def zstream[X](using ev: A =:= ValSource[X]): UStream[X] = {
     def go(port: Port[ValSource[X]]): UStream[X] =

--- a/mashup/src/main/scala/libretto/mashup/BodyType.scala
+++ b/mashup/src/main/scala/libretto/mashup/BodyType.scala
@@ -3,8 +3,8 @@ package libretto.mashup
 import libretto.util.Async
 import scala.util.{Failure, Success, Try}
 import zio.Chunk
-import zio.json.ast.{Json => ZioJson}
-import zio.json.ast.Json.{encoder => JsonEncoder}
+import zio.json.ast.{Json as ZioJson}
+import zio.json.ast.Json.{encoder as JsonEncoder}
 import zio.http.{Body, Response}
 import zio.http.model.{Headers, Status}
 

--- a/mashup/src/main/scala/libretto/mashup/ServiceOutput.scala
+++ b/mashup/src/main/scala/libretto/mashup/ServiceOutput.scala
@@ -5,7 +5,7 @@ import libretto.mashup.dsl.{-->, Fun, Unlimited}
 import libretto.mashup.rest.{Endpoint, Path, RestApi}
 import libretto.mashup.ZioHttpServer.{NextRequest, RequestStream}
 import zio.{Promise, Scope, ZIO}
-import zio.http.{Path => ZPath, Request, Response}
+import zio.http.{Path as ZPath, Request, Response}
 import zio.http.model.Status
 
 sealed trait ServiceOutput[A] {

--- a/stream/src/main/scala/libretto/stream/scaletto/ScalettoStreams.scala
+++ b/stream/src/main/scala/libretto/stream/scaletto/ScalettoStreams.scala
@@ -477,7 +477,7 @@ abstract class ScalettoStreams {
     )(using
       Ordering[K],
     ): (ValSource[A] |*| Source[Val[K] |*| -[ValSource[V]]]) -⚬ Done = {
-      import ValSource.{DemandingTree => DT}
+      import ValSource.{DemandingTree as DT}
       import DemandingTree.NeDT
       type KSubs = Val[K] |*| -[ValSource[V]]
 

--- a/stream/src/test/scala/libretto/stream/StreamsTests.scala
+++ b/stream/src/test/scala/libretto/stream/StreamsTests.scala
@@ -171,7 +171,7 @@ class StreamsTests extends ScalatestScalettoTestSuite {
       "broadcastByKey" -> TestCase
         .interactWith {
           import ValSource.broadcastByKey
-          import ValSource.BroadcastByKey.{close => closeBroadcast, subscribe}
+          import ValSource.BroadcastByKey.{close as closeBroadcast, subscribe}
 
           val byLength: Val[String] -⚬ (Val[Int] |*| Val[String]) =
             mapVal[String, (Int, String)](s => (s.length, s)) > liftPair

--- a/testing/src/main/scala/libretto/testing/TestKit.scala
+++ b/testing/src/main/scala/libretto/testing/TestKit.scala
@@ -1,7 +1,7 @@
 package libretto.testing
 
 import libretto.{CoreBridge, CoreDSL, ExecutionParams, Monad}
-import libretto.lambda.util.{Monad => ScalaMonad, SourcePos}
+import libretto.lambda.util.{Monad as ScalaMonad, SourcePos}
 import libretto.lambda.util.Monad.syntax.*
 import libretto.util.Async
 import scala.annotation.targetName

--- a/testing/src/main/scala/libretto/testing/TestResult.scala
+++ b/testing/src/main/scala/libretto/testing/TestResult.scala
@@ -1,7 +1,7 @@
 package libretto.testing
 
 import libretto.lambda.util.SourcePos
-import scala.{:: => NonEmptyList}
+import scala.{:: as NonEmptyList}
 import scala.concurrent.duration.FiniteDuration
 
 enum TestResult[A] {

--- a/testing/src/main/scala/libretto/testing/scaletto/ScalettoTestExecutor.scala
+++ b/testing/src/main/scala/libretto/testing/scaletto/ScalettoTestExecutor.scala
@@ -29,7 +29,7 @@ object ScalettoTestExecutor {
         ScalettoTestExecutor.ExecutionParam.manualClockParamsInstance
 
       private val coreLib = CoreLib(this.dsl)
-      import coreLib.{Monad => _, *}
+      import coreLib.{Monad as _, *}
 
       override def success[A]: A -⚬ Assertion[A] =
         injectR
@@ -46,7 +46,7 @@ object ScalettoTestExecutor {
       override def extractOutcome(using exn: Execution, pos: SourcePos)(
         outPort: exn.OutPort[Assertion[Done]],
       ): Outcome[Unit] = {
-        import TestResult.{crash, success => succeed, failed => fail}
+        import TestResult.{crash, success as succeed, failed as fail}
         Outcome.asyncTestResult(
           exn.OutPort
             .awaitEither[Val[String], Done](outPort)


### PR DESCRIPTION
There was a small oversight left. Now also the new `as` syntax is used.